### PR TITLE
Objectives: use 'trigger'-clauses, general clean-up

### DIFF
--- a/CleanSlate/common/objectives/00_HF_ambitions.txt
+++ b/CleanSlate/common/objectives/00_HF_ambitions.txt
@@ -11,17 +11,17 @@ obj_create_treasury = {
 
 	potential = {
 		has_dlc = "Holy Fury"
+		is_landed = yes
+		higher_tier_than = BARON
+		is_adult = yes
 		NOR = {
 			has_character_flag = created_treasury
 			any_artifact = {
 				quality >= 2
 			}
-			is_incapable = yes
-			is_inaccessible_trigger = yes
 		}
-		is_landed = yes
-		higher_tier_than = BARON
-		is_adult = yes
+		is_incapable = no
+		is_inaccessible_trigger = no
 	}
 
 	success = {
@@ -29,7 +29,7 @@ obj_create_treasury = {
 			text = create_treasury_condition_tooltip
 
 			any_artifact = {
-				count = 3
+				count >= 3
 				quality >= 2
 			}
 		}
@@ -58,16 +58,16 @@ obj_make_friends = {
 
 	potential = {
 		has_dlc = "Holy Fury"
-		num_of_friends < 1
-		NOR = {
-			has_character_flag = made_friends
-			trait = shy
-			is_incapable = yes
-			is_inaccessible_trigger = yes
-		}
 		is_landed = yes
 		higher_tier_than = BARON
 		is_adult = yes
+		num_of_friends < 1
+		is_incapable = no
+		is_inaccessible_trigger = no
+		NOR = {
+			has_character_flag = made_friends
+			trait = shy
+		}
 	}
 
 	success = {
@@ -107,10 +107,10 @@ obj_forge_bloodline = {
 		is_playable = yes
 		higher_tier_than = COUNT
 		age >= 6
+		is_incapable = no
 
 		NOR = {
 			trait = content
-			is_incapable = yes
 			any_owned_bloodline = { # Should not already have a created bloodline
 				has_bloodline_flag = created_bloodline
 			}
@@ -119,134 +119,219 @@ obj_forge_bloodline = {
 		trigger_if = { # The AI shouldn't create bloodlines when they already have a historical one
 			limit = { ai = yes }
 
-			any_owned_bloodline = {
-				has_bloodline_flag = historical_bloodline
+			NOT = {
+				any_owned_bloodline = {
+					has_bloodline_flag = historical_bloodline
+				}
 			}
 		}
 
 		trigger_if = {
 			limit = { has_dynasty_flag = flag_dynasty_forged_bloodline }
-			OR = {
-				prestige >= 20000 # Adults
-				AND = { # Child facilitation
-					prestige >= 15000
-					is_adult = no
-					OR = {
-						trait = willful
-						trait = proud
-						trait = ambitious
-						trait = quick
-						trait = genius
-					}
+
+			trigger_if = {
+				limit = { is_adult = no }
+
+				prestige >= 15000
+
+				OR = {
+					trait = willful
+					trait = proud
+					trait = ambitious
+					trait = quick
+					trait = genius
 				}
+			}
+			trigger_else = {
+				prestige >= 20000
 			}
 		}
 		trigger_else = {
-			OR = {
-				prestige >= 5000 # Adults
-				AND = { # Child facilitation
-					prestige >= 2500
-					is_adult = no
-					OR = {
-						trait = willful
-						trait = proud
-						trait = ambitious
-						trait = quick
-						trait = genius
-					}
+			trigger_if = {
+				limit = { is_adult = no }
+
+				prestige >= 2500
+
+				OR = {
+					trait = willful
+					trait = proud
+					trait = ambitious
+					trait = quick
+					trait = genius
 				}
+			}
+			trigger_else = {
+				prestige >= 5000
 			}
 		}
 	}
 
 	creation_effect = {
 		if = {
-			limit = {
-				age < 12
-			}
-			set_character_flag = flag_forge_bloodline_was_child # Checked to unlock special flavor.
+			limit = { age < 12 }
+
+			# Checked to unlock special flavor
+			set_character_flag = flag_forge_bloodline_was_child
 		}
 
 		# Set variables immediately so that the 0s show in the tooltip
 		if = {
 			limit = {
-				NOT = { check_variable = { which = bloodline_murdered_people value = 1 } }
+				check_variable = {
+					which = bloodline_murdered_people
+					value < 1
+				}
 			}
-			set_variable = { which = bloodline_murdered_people value = 0 }
+			set_variable = {
+				which = bloodline_murdered_people
+				value = 0
+			}
 		}
 		if = {
 			limit = {
-				NOT = { check_variable = { which = bloodline_won_wars value = 1 } }
+				check_variable = {
+					which = bloodline_won_wars
+					value < 1
+				}
 			}
-			set_variable = { which = bloodline_won_wars value = 0 }
+			set_variable = {
+				which = bloodline_won_wars
+				value = 0
+			}
 		}
 		if = {
 			limit = {
-				NOT = { check_variable = { which = bloodline_built_holdings value = 1 } }
+				check_variable = {
+					which = bloodline_built_holdings
+					value < 1
+				}
 			}
-			set_variable = { which = bloodline_built_holdings value = 0 }
+			set_variable = {
+				which = bloodline_built_holdings
+				value = 0
+			}
 		}
 		if = {
 			limit = {
-				NOT = { check_variable = { which = bloodline_built_cities value = 1 } }
+				check_variable = {
+					which = bloodline_built_cities
+					value < 1
+				}
 			}
-			set_variable = { which = bloodline_built_cities value = 0 }
+			set_variable = {
+				which = bloodline_built_cities
+				value = 0
+			}
 		}
 		if = {
 			limit = {
-				NOT = { check_variable = { which = bloodline_built_castles value = 1 } }
+				check_variable = {
+					which = bloodline_built_castles
+					value < 1
+				}
 			}
-			set_variable = { which = bloodline_built_castles value = 0 }
+			set_variable = {
+				which = bloodline_built_castles
+				value = 0
+			}
 		}
 		if = {
 			limit = {
-				NOT = { check_variable = { which = bloodline_built_temples value = 1 } }
+				check_variable = {
+					which = bloodline_built_temples
+					value < 1
+				}
 			}
-			set_variable = { which = bloodline_built_temples value = 0 }
+			set_variable = {
+				which = bloodline_built_temples
+				value = 0
+			}
 		}
 
-		#If you already fulfilled one of the paths, fire event immediately
+		# If you already fulfilled one of the paths, fire event immediately
 		if = {
 			limit = {
-				check_variable = { which = bloodline_murdered_people value = 30 }
+				check_variable = {
+					which = bloodline_murdered_people
+					value >= 30
+				}
 			}
 			set_character_flag = flag_about_to_murder_bloodline
-			character_event = { id = HF.24025 days = 25 random = 25 }
+			character_event = {
+				id = HF.24025
+				days = 25
+				random = 25
+			}
 		}
 		else_if = {
 			limit = {
-				check_variable = { which = bloodline_won_wars value = 15 }
+				check_variable = {
+					which = bloodline_won_wars
+					value >= 15
+				}
 			}
 			set_character_flag = flag_about_to_war_bloodline
-			character_event = { id = HF.24031 days = 25 random = 25 }
+			character_event = {
+				id = HF.24031
+				days = 25
+				random = 25
+			}
 		}
 		else_if = {
 			limit = {
-				check_variable = { which = bloodline_built_holdings value = 24 }
+				check_variable = {
+					which = bloodline_built_holdings
+					value >= 24
+				}
 			}
 			set_character_flag = flag_about_to_builder_bloodline
-			narrative_event = { id = HF.24047 days = 25 random = 25 }
+			narrative_event = {
+				id = HF.24047
+				days = 25
+				random = 25
+			}
 		}
 		else_if = {
 			limit = {
-				check_variable = { which = bloodline_built_cities value = 10 }
+				check_variable = {
+					which = bloodline_built_cities
+					value >= 10
+				}
 			}
 			set_character_flag = flag_about_to_builder_bloodline
-			narrative_event = { id = HF.24042 days = 25 random = 25 }
+			narrative_event = {
+				id = HF.24042
+				days = 25
+				random = 25
+			}
 		}
 		else_if = {
 			limit = {
-				check_variable = { which = bloodline_built_castles value = 10 }
+				check_variable = {
+					which = bloodline_built_castles
+					value >= 10
+				}
 			}
 			set_character_flag = flag_about_to_builder_bloodline
-			narrative_event = { id = HF.24043 days = 25 random = 25 }
+			narrative_event = {
+				id = HF.24043
+				days = 25
+				random = 25
+			}
 		}
 		else_if = {
 			limit = {
-				check_variable = { which = bloodline_built_temples value = 10 }
+				check_variable = {
+					which = bloodline_built_temples
+					value >= 10
+				}
 			}
 			set_character_flag = flag_about_to_builder_bloodline
-			narrative_event = { id = HF.24044 days = 25 random = 25 }
+			narrative_event = {
+				id = HF.24044
+				days = 25
+				random = 25
+			}
 		}
 
 		# Otherwise delayed fire of event bloodlines chain
@@ -255,13 +340,23 @@ obj_forge_bloodline = {
 				higher_real_tier_than = DUKE
 				ai = no
 			}
-			character_event = { id = HF.24052 days = 800 random = 800 }
+			character_event = {
+				id = HF.24052
+				days = 800
+				random = 800
+			}
 		}
 
 		# Finally, set counter for years at peace
-		set_variable = { which = bloodline_peaceful_years value = 0 }
+		set_variable = {
+			which = bloodline_peaceful_years
+			value = 0
+		}
 		# And start increasing it. on_started_war actions will reset it
-		character_event = { id = HF.24020 days = 365 }
+		character_event = {
+			id = HF.24020
+			days = 365
+		}
 	}
 
 	success = {
@@ -317,37 +412,32 @@ obj_forge_bloodline = {
 	chance = {
 		factor = 10
 
-		modifier = {
-			factor = 0
-			NOR = {
+		trigger = {
+			OR = {
 				trait = ambitious
 				trait = proud
 				trait = willful
 			}
-		}
-		modifier = {
-			factor = 0
-			OR = {
+
+			NOR = {
 				trait = humble
 				trait = timid
-			}
-		}
-		modifier = {
-			factor = 100
-			trait = ambitious
-		}
-		modifier = {
-			factor = 0
-			# The AI shouldn't try to create a new bloodline if they are already the founder of one (from legendary journey, crusades, etc.), but that's fine for the player
-			any_owned_bloodline = {
-				founder = {
-					character = ROOT
+
+				# Don't step on the player's dreams, AI.
+				any_dynasty_member = { ai = no }
+
+				# The AI shouldn't try to create a new bloodline if they are already the founder of one (from legendary journey, crusades, etc.), but that's fine for the player
+				any_owned_bloodline = {
+					founder = {
+						character = ROOT
+					}
 				}
 			}
 		}
-		modifier = {
-			factor = 0
-			any_dynasty_member = { ai = no } # Don't step on the player's dreams, AI.
+
+		mult_modifier = {
+			factor = 100
+			trait = ambitious
 		}
 	}
 }

--- a/CleanSlate/common/objectives/00_JD_ambitions.txt
+++ b/CleanSlate/common/objectives/00_JD_ambitions.txt
@@ -11,65 +11,69 @@ obj_strengthen_religion = {
 
 	potential = {
 		has_dlc = "Jade Dragon"
-		religion_authority < 0.30
-		is_playable = yes
+		independent = yes
 		is_landed = yes
 		higher_tier_than = BARON
+		NOT = { religion_authority >= 0.30 }
 		is_nomadic = no
-		liege = { is_nomadic = no }
-		independent = yes
 		is_adult = yes
-		NOR = {
-			has_character_flag = strengthened_religion
-			is_incapable = yes
-			has_secret_religion = yes
-			is_devil_worshiper_trigger = yes
-			is_inaccessible_trigger = yes
-		}
+		has_secret_religion = no
+		is_devil_worshiper_trigger = no
+		is_inaccessible_trigger = no
+		is_incapable = no
+		NOT = { has_character_flag = strengthened_religion }
 	}
 
 	creation_effect = {
-		change_variable = { which = strengthen_religion value = 0 }
+		change_variable = {
+			which = strengthen_religion
+			value = 0
+		}
 
 		random_list = {
 			150 = { # No Opportunity
 				set_character_flag = had_ambition_opportunity_chance
 			}
+
 			50 = { # Liberate Opportunity
-				character_event = { id = JD.2100 days = 14 random = 14 }
+				character_event = {
+					id = JD.2100
+					days = 14
+					random = 14
+
+				}
+
 				set_character_flag = had_ambition_opportunity_chance
-				modifier = {
-					factor = 0
+
+				trigger = {
+					mercenary = no
+					pacifist = no
+
 					NOR = {
-						is_nomadic = no
-						mercenary = no
-						pacifist = no
-						top_liege = {
-							religion = ROOT
-						}
-						any_realm_province = { 											# You need a province...
-							any_neighbor_province = {									# ... that has a neighbor province...
-								holder_scope = {										# ... whos holder is...
-									NOT = { same_realm = ROOT } 						# ... not in your realm...
-									top_liege = {										# ... and has a Top Liege...
-										NOT = { religion = ROOT }						# ... who is NOT of your religion...
-										any_realm_province = {							# ... and has any province in their realm...
-											religion = ROOT								# ... that is of your religion...
-											kingdom = {									# ... and a De Jure part of a Kingdom, created or not...
-												any_de_jure_vassal_title = { 			# ... who contains any title...
-													tier = COUNT						# ... of Count tier...
-													holder_scope = {					# ... that is in the same realm as the Top Liege of the neighbor
-														same_realm = PREVPREVPREVPREV	# Province's holder...
-													}
-													location = {						# ... and where the associated province...
-														any_neighbor_province = {		# ... has a neighboring province...
-															holder_scope = {			# ... whos holder...
-																top_liege = {			# ... has a Top Liege...
-																	character = ROOT	# ... who is you!
-																}
-															}
-														}
-													}
+						trait = cynical
+						has_character_flag = had_liberate_opportunity
+						has_character_flag = had_ambition_opportunity_chance
+					}
+
+					any_neighbor_independent_ruler = {								# You need to neighbour a ruler
+						NOT = { religion = ROOT }                                   # ... who is NOT of your religion
+
+						any_realm_province = {                                      # ... and has any province in their realm...
+							religion = ROOT                                         # ... that is of your religion...
+
+							kingdom = {                                             # ... and a De Jure part of a Kingdom, created or not...
+								any_de_jure_vassal_title = {                        # ... which contains any title...
+									tier = COUNT                                    # ... of Count tier...
+
+									holder_scope = {                                # ... that is in the same realm as the Top Liege of the neighbor
+										same_realm = PREVPREVPREVPREV               # ... Province's holder...
+									}
+
+									location = {                                    # ... and where the associated province...
+										any_neighbor_province = {                   # ... has a neighboring province...
+											holder_scope = {                        # ... whose holder...
+												top_liege = {                       # ... has a Top Liege...
+													character = ROOT                # ... who is you!
 												}
 											}
 										}
@@ -79,29 +83,14 @@ obj_strengthen_religion = {
 						}
 					}
 				}
-				modifier = {
+
+				mult_modifier = {
 					trait = zealous
 					factor = 5
 				}
-				modifier = {
-					ai = no
-					factor = 3
-				}
-				modifier = {
+				mult_modifier = {
 					has_focus = focus_theology
 					factor = 2
-				}
-				modifier = {
-					trait = cynical
-					factor = 0
-				}
-				modifier = {
-					has_character_flag = had_liberate_opportunity
-					factor = 0
-				}
-				modifier = {
-					has_character_flag = had_ambition_opportunity_chance
-					factor = 0
 				}
 			}
 		}
@@ -111,16 +100,19 @@ obj_strengthen_religion = {
 		custom_tooltip = {
 			text = tooltip_obj_strengthen_religion
 
-			check_variable = { which = strengthen_religion value = 3 }
+			check_variable = {
+				which = strengthen_religion
+				value = 3
+			}
 		}
 	}
 
 	effect = {
+		piety = 100
 		religion_authority = {
 			modifier = strengthened_religion
 			years = 50
 		}
-		piety = 100
 		add_character_modifier = {
 			modifier = strengthen_religion_ambition
 			years = 30

--- a/CleanSlate/common/objectives/00_LT_ambitions.txt
+++ b/CleanSlate/common/objectives/00_LT_ambitions.txt
@@ -3,22 +3,22 @@ obj_create_wonder = {
 	type = character
 
 	potential = {
+		independent = yes
+		is_landed = yes
+		is_adult = yes
+
 		has_game_rule = {
 			name = wonder_rule
 			value = on
 		}
-		NOR = {
-			has_character_flag = created_wonder
-			has_wonder = yes
-			has_started_building_wonder = yes
-			is_incapable = yes
-			is_inaccessible_trigger = yes
-		}
+
+		NOT = { has_character_flag = created_wonder }
+		has_wonder = no
+		has_started_building_wonder = no
+		is_incapable = no
+		is_inaccessible_trigger = no
 		wealth >= 1000
 		prestige >= 500
-		is_landed = yes
-		independent = yes
-		is_adult = yes
 	}
 
 	success = {
@@ -27,6 +27,7 @@ obj_create_wonder = {
 
 			any_realm_wonder = {
 				wonder_stage >= 2
+
 				original_wonder_owner = {
 					character = ROOT
 				}
@@ -39,6 +40,7 @@ obj_create_wonder = {
 			text = create_wonder_effect_tooltip
 
 			set_character_flag = created_wonder
+
 			random_list = {
 				100 = {
 					trigger = {

--- a/CleanSlate/common/objectives/00_ambitions.txt
+++ b/CleanSlate/common/objectives/00_ambitions.txt
@@ -29,6 +29,7 @@ obj_become_chancellor = {
 				NOT = { has_character_flag = successful_council_ambition }
 			}
 			change_diplomacy = 1
+			set_character_flag = successful_council_ambition
 		}
 
 		opinion = {
@@ -36,8 +37,6 @@ obj_become_chancellor = {
 			modifier = opinion_ambition_fulfilled
 			years = 5
 		}
-
-		set_character_flag = successful_council_ambition
 	}
 
 	abort = {
@@ -53,66 +52,66 @@ obj_become_chancellor = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = shy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			from_ruler_dynasty = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = poet
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = falconer
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = gregarious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = naive_appeaser
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = underhanded_rogue
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			OR = {
 				trait = charismatic_negotiator
 				trait = grey_eminence
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			diplomacy >= 10
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			diplomacy >= 12
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			diplomacy >= 14
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			diplomacy >= 16
 		}
@@ -141,6 +140,7 @@ obj_become_marshal = {
 				NOT = { has_character_flag = successful_council_ambition }
 			}
 			change_martial = 1
+			set_character_flag = successful_council_ambition
 		}
 
 		opinion = {
@@ -148,8 +148,6 @@ obj_become_marshal = {
 			modifier = opinion_ambition_fulfilled
 			years = 5
 		}
-
-		set_character_flag = successful_council_ambition
 	}
 
 	abort = {
@@ -165,66 +163,66 @@ obj_become_marshal = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			from_ruler_dynasty = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = duelist
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = hunter
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = misguided_warrior
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = tough_soldier
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			OR = {
 				trait = skilled_tactician
 				trait = brilliant_strategist
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			martial >= 10
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			martial >= 12
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			martial >= 14
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			martial >= 16
 		}
@@ -254,13 +252,14 @@ obj_become_treasurer = {
 				NOT = { has_character_flag = successful_council_ambition }
 			}
 			change_stewardship = 1
+			set_character_flag = successful_council_ambition
 		}
+
 		opinion = {
 			who = liege
 			modifier = opinion_ambition_fulfilled
 			years = 5
 		}
-		set_character_flag = successful_council_ambition
 	}
 
 	abort = {
@@ -276,74 +275,74 @@ obj_become_treasurer = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			from_ruler_dynasty = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = scholar
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = gardener
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = gluttonous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = temperate
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = indulgent_wastrel
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = thrifty_clerk
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			OR = {
 				trait = fortune_builder
 				trait = midas_touched
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			stewardship >= 10
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			stewardship >= 12
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			stewardship >= 14
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			stewardship >= 16
 		}
@@ -372,6 +371,7 @@ obj_become_spymaster = {
 				NOT = { has_character_flag = successful_council_ambition }
 			}
 			change_intrigue = 1
+			set_character_flag = successful_council_ambition
 		}
 
 		opinion = {
@@ -379,8 +379,6 @@ obj_become_spymaster = {
 			modifier = opinion_ambition_fulfilled
 			years = 5
 		}
-
-		set_character_flag = successful_council_ambition
 	}
 
 	abort = {
@@ -396,74 +394,74 @@ obj_become_spymaster = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			from_ruler_dynasty = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = mystic
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = amateurish_plotter
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = flamboyant_schemer
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			OR = {
 				trait = intricate_webweaver
 				trait = elusive_shadow
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			intrigue >= 10
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			intrigue >= 12
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			intrigue >= 14
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			intrigue >= 16
 		}
@@ -492,6 +490,7 @@ obj_become_spiritual = {
 				NOT = { has_character_flag = successful_council_ambition }
 			}
 			change_learning = 1
+			set_character_flag = successful_council_ambition
 		}
 
 		opinion = {
@@ -499,8 +498,6 @@ obj_become_spiritual = {
 			modifier = opinion_ambition_fulfilled
 			years = 5
 		}
-
-		set_character_flag = successful_council_ambition
 	}
 
 	abort = {
@@ -516,58 +513,58 @@ obj_become_spiritual = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = cynical
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			from_ruler_dynasty = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = detached_priest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = martial_cleric
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			OR = {
 				trait = scholarly_theologian
 				trait = mastermind_theologian
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			learning >= 10
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			learning >= 12
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			learning >= 14
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			learning >= 16
 		}
@@ -580,16 +577,17 @@ obj_amass_wealth = {
 	type = character
 
 	potential = {
+		is_playable = yes
+		is_landed = yes
+		is_incapable = no
+		is_adult = yes
+		wealth < 200
+
 		NOR = {
 			has_dlc = "Conclave"
 			has_character_flag = amassed_wealth
 			trait = charitable
-			is_incapable = yes
 		}
-		is_adult = yes
-		wealth < 200
-		is_playable = yes
-		is_landed = yes
 	}
 
 	success = {
@@ -611,23 +609,23 @@ obj_amass_wealth = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = fortune_builder
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = midas_touched
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
@@ -638,15 +636,15 @@ obj_become_paragon_of_virtue = {
 	type = character
 
 	potential = {
+		NOT = { religion_group = indian_group }
 		is_playable = yes
 		is_landed = yes
 		is_adult = yes
+		is_incapable = no
 		piety < 1000
-		NOR = {
-			religion_group = indian_group
-			is_incapable = yes
-			has_impious_trait_trigger = yes
-		}
+
+		has_impious_trait_trigger = no
+
 		OR = {
 			has_education_learning_trigger = yes
 			has_pious_trait_trigger = yes
@@ -662,9 +660,7 @@ obj_become_paragon_of_virtue = {
 		piety = 100
 
 		if = {
-			limit = {
-				has_nickname = no
-			}
+			limit = { has_nickname = no }
 			give_nickname = nick_the_holy
 		}
 
@@ -696,7 +692,10 @@ obj_become_paragon_of_virtue = {
 		# Achievement
 		hidden_effect = {
 			if = {
-				limit = { ai = no }
+				limit = {
+					ai = no
+					is_ironman = yes
+				}
 				set_character_flag = achievement_become_paragon_of_virtue
 			}
 		}
@@ -712,22 +711,20 @@ obj_become_paragon_of_virtue = {
 	chance = {
 		factor = 50
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
-			NOR = {
-				higher_tier_than = DUKE
-				is_theocracy = yes
-			}
+			lower_tier_than = KING
+			is_theocracy = no
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			has_education_learning_trigger = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			trait = zealous
 		}
@@ -738,17 +735,19 @@ obj_become_exalted = {
 	type = character
 
 	potential = {
+		is_playable = yes
+		is_landed = yes
+		is_incapable = no
+		is_adult = yes
+		prestige < 1000
+
 		NOR = {
 			has_character_flag = became_exalted
 			trait = content
 			trait = humble
 			trait = shy
-			is_incapable = yes
 		}
-		is_adult = yes
-		prestige < 1000
-		is_playable = yes
-		is_landed = yes
+
 		OR = {
 			higher_tier_than = DUKE
 			trait = ambitious
@@ -776,7 +775,10 @@ obj_become_exalted = {
 		# Achievement
 		hidden_effect = {
 			if = {
-				limit = { ai = no }
+				limit = {
+					ai = no
+					is_ironman = yes
+				}
 				set_character_flag = achievement_become_exalted
 			}
 			set_character_flag = became_exalted
@@ -795,19 +797,19 @@ obj_become_exalted = {
 	chance = {
 		factor = 50
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			lower_tier_than = KING
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			trait = proud
 		}
@@ -822,28 +824,35 @@ obj_get_married = {
 			limit = { has_dlc = "Conclave" }
 			ai = yes
 		}
+
 		trigger_if = {
 			limit = { is_female = yes }
 			age < 40
 		}
+
+		trigger_if = {
+			limit = { is_ruler = yes }
+
+			OR = {
+				is_feudal = yes
+				is_tribal = yes
+				is_nomadic = yes
+				is_patrician = yes
+			}
+		}
+
 		is_married = no
 		is_consort = no
 		can_marry = yes
 		prisoner = no
 		is_marriage_adult = yes
+		is_incapable = no
+		is_ascetic_trigger = no
+
 		NOR = {
 			trait = celibate
-			is_incapable = yes
 			trait = eunuch
-			is_ascetic_trigger = yes
 			has_landed_title = k_papal_state
-		}
-		OR = {
-			is_ruler = no
-			is_feudal = yes
-			is_tribal = yes
-			is_nomadic = yes
-			is_patrician = yes
 		}
 	}
 
@@ -872,20 +881,20 @@ obj_get_married = {
 
 	abort = {
 		OR = {
-			AND = {
-				is_priest = yes
+			trigger_if = {
+				limit = { is_priest = yes }
 				can_marry = no
 			}
-			AND = {
-				is_female = yes
+			trigger_if = {
+				limit = { is_female = yes }
 				is_ruler = no
 				age >= 40
 			}
-			has_landed_title = k_papal_state
-			trait = celibate
 			is_incapable = yes
+			trait = celibate
 			trait = eunuch
 			is_ascetic_trigger = yes
+			has_landed_title = k_papal_state
 		}
 	}
 
@@ -898,43 +907,43 @@ obj_get_married = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			trait = homosexual
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			is_female = yes
 			has_religion_feature = religion_matriarchal
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			is_female = no
 			has_religion_feature = religion_patriarchal
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = shy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = lustful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			age = 25
+			age >= 25
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5.0
-			age = 35
+			age >= 35
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
-			age = 40
+			age >= 40
 		}
 	}
 }
@@ -950,23 +959,21 @@ obj_marry_ruler = {
 
 		trigger_if = {
 			limit = { is_female = yes }
-			age < 45
 			NOT = { has_religion_feature = religion_matriarchal }
 		}
 		trigger_else = {
-			age < 45
 			has_religion_feature = religion_matriarchal
 		}
 
+		age < 45
 		is_married = no
 		is_consort = no
 		can_marry = yes
 		prisoner = no
 		is_marriage_adult = yes
-		NOR = {
-			trait = celibate
-			is_incapable = yes
-		}
+		is_incapable = no
+		NOT = { trait = celibate }
+
 		father = {
 			primary_title = {
 				higher_tier_than = COUNT
@@ -1007,19 +1014,19 @@ obj_marry_ruler = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = midas_touched
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = elusive_shadow
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5.0
 			trait = ambitious
 		}
@@ -1035,13 +1042,12 @@ obj_have_a_daughter = {
 		NOR = {
 			has_dlc = "Conclave"
 			trait = celibate
-			is_incapable = yes
 			any_child = {
 				is_female = yes
 			}
-			prisoner = yes
 		}
-
+		is_incapable = no
+		prisoner = no
 		is_marriage_adult = yes
 		age < 75
 
@@ -1050,16 +1056,19 @@ obj_have_a_daughter = {
 			is_consort = yes
 		}
 
-		OR = {
-			ai = no
-			is_female = yes
-			num_of_children >= 2
-			has_religion_feature = religion_matriarchal
-		}
-
 		trigger_if = {
 			limit = { is_female = yes }
 			age < 45
+		}
+
+		trigger_if = {
+			limit = { ai = yes }
+
+			OR = {
+				is_female = yes
+				num_of_children >= 2
+				has_religion_feature = religion_matriarchal
+			}
 		}
 	}
 
@@ -1075,9 +1084,9 @@ obj_have_a_daughter = {
 
 	abort = {
 		OR = {
-			AND = {
+			trigger_if = {
+				limit = { is_female = yes }
 				age >= 45
-				is_female = yes
 			}
 			age >= 75
 			trait = celibate
@@ -1088,25 +1097,25 @@ obj_have_a_daughter = {
 	chance = {
 		factor = 50
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			has_religion_feature = religion_patriarchal
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			has_religion_feature = religion_matriarchal
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			num_of_children = 3
+			num_of_children >= 3
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
-			num_of_children = 4
+			num_of_children >= 4
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
-			num_of_children = 5
+			num_of_children >= 5
 		}
 	}
 }
@@ -1118,16 +1127,16 @@ obj_have_a_son = {
 	fertility = 0.25
 
 	allow = {
-		NOT = {
+		NOR = {
 			has_dlc = "Conclave"
-			prisoner = yes
 			any_child = {
 				is_female = no
 			}
 			trait = celibate
-			is_incapable = yes
 		}
 
+		is_incapable = no
+		prisoner = no
 		is_marriage_adult = yes
 		age < 75
 
@@ -1136,21 +1145,24 @@ obj_have_a_son = {
 			is_consort = yes
 		}
 
-		OR = {
-			ai = no
-			is_female = no
-			has_religion_feature = religion_patriarchal
-
-			# Have at least two daughters
-			any_child = {
-				count = 2
-				is_female = yes
-			}
-		}
-
 		trigger_if = {
 			limit = { is_female = yes }
 			age < 45
+		}
+
+		trigger_if = {
+			limit = { ai = yes }
+
+			OR = {
+				is_female = no
+				has_religion_feature = religion_patriarchal
+
+				# Have at least two daughters
+				any_child = {
+					count >= 2
+					is_female = yes
+				}
+			}
 		}
 	}
 
@@ -1166,9 +1178,9 @@ obj_have_a_son = {
 
 	abort = {
 		OR = {
-			AND = {
+			trigger_if = {
+				limit = { is_female = yes }
 				age >= 45
-				is_female = yes
 			}
 			age >= 75
 			trait = celibate
@@ -1179,25 +1191,25 @@ obj_have_a_son = {
 	chance = {
 		factor = 50
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			has_religion_feature = religion_matriarchal
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			has_religion_feature = religion_patriarchal
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			num_of_children = 3
+			num_of_children >= 3
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
-			num_of_children = 4
+			num_of_children >= 4
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
-			num_of_children = 5
+			num_of_children >= 5
 		}
 	}
 }
@@ -1227,11 +1239,12 @@ obj_wants_landed_title = {
 			NOT = { has_religion_feature = religion_matriarchal }
 		}
 
+		prisoner = no
+		is_incapable = no
+		is_ascetic_trigger = no
+
 		NOR = {
-			prisoner = yes
-			is_incapable = yes
 			trait = eunuch
-			is_ascetic_trigger = yes
 			has_minor_title = title_guru
 		}
 
@@ -1240,20 +1253,17 @@ obj_wants_landed_title = {
 				is_feudal = yes
 				is_tribal = yes
 			}
+
 			is_close_relative = ROOT
 			num_of_extra_landed_titles >= 1
 
-			OR = {
-				NOT = { is_parent_of = ROOT }
-				NOT = {
-					current_heir = {
-						character = ROOT
-					}
+			NAND = {
+				is_parent_of = ROOT
+				current_heir = {
+					character = ROOT
 				}
-				NOT = {
-					primary_title = {
-						has_law = succ_gavelkind
-					}
+				primary_title = {
+					has_law = succ_gavelkind
 				}
 			}
 		}
@@ -1307,40 +1317,38 @@ obj_wants_landed_title = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			religion_group = muslim
-			liege = {
-				dynasty = ROOT
-			}
+			dynasty = liege
 		}
 	}
 }
@@ -1354,26 +1362,25 @@ obj_become_heir = {
 			ai = yes
 		}
 
-		liege = {
-			is_parent_of = ROOT
-		}
+		is_child_of = liege
+		is_adult = yes
+		prisoner = no
+		is_primary_heir = no
+		is_incapable = no
+		NOT = { trait = bastard }
 
 		trigger_if = {
 			limit = { is_female = yes }
 			liege = {
 				primary_title = {
-					NOT = {
-						has_law = agnatic_succession
-					}
+					NOT = { has_law = agnatic_succession }
 				}
 			}
 		}
 		trigger_else = {
 			liege = {
 				primary_title = {
-					NOT = {
-						has_law = enatic_succession
-					}
+					NOT = { has_law = enatic_succession }
 				}
 			}
 		}
@@ -1383,22 +1390,13 @@ obj_become_heir = {
 				is_primary_heir = yes
 				OR = {
 					has_epidemic = yes
+					is_incapable = yes
 					is_ill = yes
 					trait = lunatic
 					trait = possessed
-					is_incapable = yes
 					trait = infirm
 				}
 			}
-		}
-
-		is_adult = yes
-
-		NOR = {
-			prisoner = yes
-			is_primary_heir = yes
-			is_incapable = yes
-			trait = bastard
 		}
 	}
 
@@ -1420,27 +1418,27 @@ obj_become_heir = {
 	chance = {
 		factor = 50
 
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
@@ -1456,11 +1454,11 @@ obj_improve_martial = {
 	potential = {
 		NOR = {
 			has_dlc = "Way of Life"
-			prisoner = yes
-			is_incapable = yes
 			trait = infirm
 		}
 		is_playable = yes
+		prisoner = no
+		is_incapable = no
 		age >= 16
 		martial < 8
 	}
@@ -1494,23 +1492,23 @@ obj_improve_martial = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = misguided_warrior
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -1524,13 +1522,13 @@ obj_improve_stewardship = {
 	potential = {
 		NOR = {
 			has_dlc = "Way of Life"
-			prisoner = yes
-			is_incapable = yes
 			trait = infirm
 		}
 		is_playable = yes
+		prisoner = no
+		is_incapable = no
 		age >= 16
-		stewardship <= 8
+		stewardship < 8
 	}
 
 	success = {
@@ -1565,23 +1563,23 @@ obj_improve_stewardship = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = indulgent_wastrel
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -1595,13 +1593,13 @@ obj_improve_learning = {
 	potential = {
 		NOR = {
 			has_dlc = "Way of Life"
-			prisoner = yes
-			is_incapable = yes
 			trait = infirm
 		}
 		is_playable = yes
+		prisoner = no
+		is_incapable = no
 		age >= 16
-		learning <= 8
+		learning < 8
 	}
 
 	success = {
@@ -1632,23 +1630,23 @@ obj_improve_learning = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = detached_priest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -1662,13 +1660,13 @@ obj_improve_diplomacy = {
 	potential = {
 		NOR = {
 			has_dlc = "Way of Life"
-			prisoner = yes
-			is_incapable = yes
 			trait = infirm
 		}
 		is_playable = yes
+		prisoner = no
+		is_incapable = no
 		age >= 16
-		diplomacy <= 8
+		diplomacy < 8
 	}
 
 	success = {
@@ -1699,23 +1697,23 @@ obj_improve_diplomacy = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = naive_appeaser
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -1729,13 +1727,13 @@ obj_improve_intrigue = {
 	potential = {
 		NOR = {
 			has_dlc = "Way of Life"
-			prisoner = yes
-			is_incapable = yes
 			trait = infirm
 		}
 		is_playable = yes
+		prisoner = no
+		is_incapable = no
 		age >= 16
-		intrigue <= 8
+		intrigue < 8
 	}
 
 	success = {
@@ -1766,23 +1764,23 @@ obj_improve_intrigue = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = naive_appeaser
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -1794,9 +1792,9 @@ obj_lower_decadence = {
 	type = character
 
 	potential = {
-		is_adult = yes
-		is_ruler = yes
 		uses_decadence = yes
+		is_ruler = yes
+		is_adult = yes
 		decadence >= 60
 		is_incapable = no
 	}
@@ -1826,23 +1824,23 @@ obj_lower_decadence = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = naive_appeaser
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -1857,21 +1855,19 @@ obj_become_king = {
 	can_cancel = no
 
 	potential = {
-		is_adult = yes
 		is_playable = yes
 		is_landed = yes
+		is_adult = yes
 		lower_tier_than = KING
+		is_incapable = no
 
 		OR = {
 			independent = yes
 			liege = { independent = yes }
 		}
 
-		NOR = {
-			any_heir_title = {
-				higher_tier_than = DUKE
-			}
-			is_incapable = yes
+		any_heir_title = {
+			higher_tier_than = DUKE
 		}
 
 		capital_scope = {
@@ -1917,9 +1913,7 @@ obj_become_king = {
 
 	effect = {
 		prestige = 500
-		hidden_effect = {
-			clr_character_flag = kingdom_claimed_with_ambition
-		}
+		clr_character_flag = kingdom_claimed_with_ambition
 	}
 
 	abort = {
@@ -1943,14 +1937,14 @@ obj_become_king = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0
 			NOR = {
 				religion_group = pagan_group
 				trait = ambitious
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			capital_scope = {
 				kingdom = {
@@ -1958,15 +1952,15 @@ obj_become_king = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			OR = {
 				independent = yes
@@ -1976,23 +1970,23 @@ obj_become_king = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			tier = COUNT
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			OR = {
 				religion = finnish_pagan
@@ -2011,10 +2005,8 @@ obj_buddhist_stop_drinking = {
 		religion = buddhist
 		trait = drunkard
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2037,15 +2029,15 @@ obj_buddhist_stop_drinking = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2059,10 +2051,8 @@ obj_buddhist_reject_empty_pleasures = {
 		religion = buddhist
 		trait = hedonist
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2085,15 +2075,15 @@ obj_buddhist_reject_empty_pleasures = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2107,10 +2097,8 @@ obj_buddhist_abstain_sexual_excess = {
 		religion = buddhist
 		trait = lustful
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2133,15 +2121,15 @@ obj_buddhist_abstain_sexual_excess = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2158,10 +2146,8 @@ obj_buddhist_reject_cruelty = {
 			trait = cruel
 		}
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2187,15 +2173,15 @@ obj_buddhist_reject_cruelty = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2209,10 +2195,8 @@ obj_buddhist_temperance_food = {
 		religion = buddhist
 		trait = gluttonous
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2235,15 +2219,15 @@ obj_buddhist_temperance_food = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2257,10 +2241,8 @@ obj_buddhist_reject_greed = {
 		religion = buddhist
 		trait = greedy
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2283,15 +2265,15 @@ obj_buddhist_reject_greed = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2305,10 +2287,8 @@ obj_buddhist_reject_envy = {
 		religion = buddhist
 		trait = envious
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2331,15 +2311,15 @@ obj_buddhist_reject_envy = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2353,10 +2333,8 @@ obj_buddhist_reject_hate = {
 		religion = buddhist
 		trait = wroth
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2379,15 +2357,15 @@ obj_buddhist_reject_hate = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2401,10 +2379,8 @@ obj_buddhist_reject_pride = {
 		religion = buddhist
 		trait = proud
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2427,15 +2403,15 @@ obj_buddhist_reject_pride = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2452,10 +2428,8 @@ obj_buddhist_defeat_fear = {
 			trait = craven
 		}
 		is_adult = yes
-		NOR = {
-			is_incapable = yes
-			trait = infirm
-		}
+		is_incapable = no
+		NOT = { trait = infirm }
 	}
 
 	success = {
@@ -2481,15 +2455,15 @@ obj_buddhist_defeat_fear = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = slothful
 		}
@@ -2501,6 +2475,8 @@ obj_become_paragon_of_enlightenment = {
 
 	potential = {
 		religion_group = indian_group
+		is_playable = yes
+		is_landed = yes
 		is_adult = yes
 		piety < 1000
 		OR = {
@@ -2508,8 +2484,6 @@ obj_become_paragon_of_enlightenment = {
 			has_pious_trait_trigger = yes
 		}
 		has_impious_trait_trigger = no
-		is_playable = yes
-		is_landed = yes
 		is_incapable = no
 	}
 
@@ -2522,9 +2496,7 @@ obj_become_paragon_of_enlightenment = {
 		piety = 100
 
 		if = {
-			limit = {
-				has_nickname = no
-			}
+			limit = { has_nickname = no }
 			give_nickname = nick_the_wise
 		}
 
@@ -2541,7 +2513,7 @@ obj_become_paragon_of_enlightenment = {
 			opinion = {
 				who = ROOT
 				modifier = opinion_enlightened
-				months = 1200
+				years = 100
 			}
 		}
 	}
@@ -2556,23 +2528,20 @@ obj_become_paragon_of_enlightenment = {
 	chance = {
 		factor = 50
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
-			NOR = {
-				tier = king
-				tier = emperor
-				is_theocracy = yes
-			}
+			lower_tier_than = KING
+			is_theocracy = no
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			has_education_learning_trigger = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 10.0
 			trait = zealous
 		}
@@ -2585,16 +2554,14 @@ obj_gain_any_title = {
 
 	potential = {
 		has_dlc = "Conclave"
-		is_adult = yes
 		is_playable = yes
 		is_landed = yes
+		independent = no
+		is_adult = yes
+		is_incapable = no
+		is_nomadic = no
 		liege = { is_nomadic = no }
-		NOR = {
-			independent = yes
-			is_nomadic = yes
-			has_character_flag = gain_any_title_ambition_success
-			is_incapable = yes
-		}
+		NOR = { has_character_flag = gain_any_title_ambition_success }
 	}
 
 	success = {
@@ -2610,10 +2577,10 @@ obj_gain_any_title = {
 
 	abort = {
 		OR = {
-			independent = yes
-			is_incapable = yes
 			is_playable = no
 			is_landed = no
+			independent = yes
+			is_incapable = yes
 			has_character_flag = obj_gain_any_title_abandoned
 		}
 	}
@@ -2625,27 +2592,27 @@ obj_gain_any_title = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			is_theocracy = yes
 		}
@@ -2667,29 +2634,25 @@ obj_see_the_realm_prosper = {
 		independent = yes
 		is_adult = yes
 		higher_tier_than = BARON
+		is_nomadic = no
+		war = no
+		is_incapable = no
+		is_inaccessible_trigger = no
+		NOT = { has_character_modifier = prosper_ambition_timer }
 
 		liege = { is_nomadic = no }
 
 		any_realm_province = {
-			any_province_holding = {
-				OR = {
-					holding_type = city
-					holding_type = castle
-					holding_type = tribal
-				}
+			OR = {
+				has_castle = yes
+				has_tribal = yes
+				has_city = yes
 			}
 			NOR = {
 				has_province_modifier = depopulated_1
 				has_province_modifier = depopulated_2
 				has_province_modifier = depopulated_3
 			}
-		}
-		NOR = {
-			is_nomadic = yes
-			war = yes
-			is_incapable = yes
-			is_inaccessible_trigger = yes
-			has_character_modifier = prosper_ambition_timer
 		}
 	}
 
@@ -2704,9 +2667,7 @@ obj_see_the_realm_prosper = {
 		custom_tooltip = {
 			text = tooltip_obj_see_the_realm_prosper
 
-			NOT = {
-				has_character_modifier = prosperity_5_year
-			}
+			NOT = { has_character_modifier = prosperity_5_year }
 		}
 	}
 
@@ -2718,12 +2679,10 @@ obj_see_the_realm_prosper = {
 
 			any_realm_province = {
 				limit = {
-					any_province_holding = {
-						OR = {
-							holding_type = city
-							holding_type = castle
-							holding_type = tribal
-						}
+					OR = {
+						has_castle = yes
+						has_tribal = yes
+						has_city = yes
 					}
 					NOR = {
 						has_province_modifier = depopulated_1
@@ -2740,18 +2699,10 @@ obj_see_the_realm_prosper = {
 					is_incapable = no
 				}
 				random_list = {
-					5 = {
-						give_nickname = nick_the_gentle
-					}
-					5 = {
-						give_nickname = nick_the_affable
-					}
-					5 = {
-						give_nickname = nick_the_shrewd
-					}
-					5 = {
-						give_nickname = nick_the_gracious
-					}
+					5 = { give_nickname = nick_the_gentle }
+					5 = { give_nickname = nick_the_affable }
+					5 = { give_nickname = nick_the_shrewd }
+					5 = { give_nickname = nick_the_gracious }
 					100 = { }
 				}
 			}
@@ -2768,6 +2719,7 @@ obj_see_the_realm_prosper = {
 			is_incapable = yes
 			is_playable = no
 			is_landed = no
+
 			any_war = {
 				NOR = {
 					using_cb = peasant_revolt
@@ -2791,7 +2743,7 @@ obj_see_the_realm_prosper = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			OR = {
 				trait = wroth
@@ -2801,7 +2753,7 @@ obj_see_the_realm_prosper = {
 				trait = slothful
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			NOR = {
 				trait = architect
@@ -2815,15 +2767,15 @@ obj_see_the_realm_prosper = {
 				has_focus = focus_rulership
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_focus = focus_rulership
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			OR = {
 				trait = indulgent_wastrel

--- a/CleanSlate/common/objectives/00_factions.txt
+++ b/CleanSlate/common/objectives/00_factions.txt
@@ -20,24 +20,20 @@ faction_succ_seniority = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		NOT = { religion_group = muslim }
+		higher_tier_than = BARON
 		is_adult = yes
+		independent = no
+		prisoner = no
+		is_incapable = no
+		holy_order = no
 
 		NOR = {
-			is_incapable = yes
-			religion_group = muslim
 			in_faction = faction_succ_primogeniture
 			in_faction = faction_succ_feudal_elective
 			in_faction = faction_succ_gavelkind
 			has_character_modifier = faction_succ_seniority_ultimatum_timer
-		}
-
-		primary_title = {
-			higher_tier_than = BARON
-			holy_order = no
 		}
 
 		liege = {
@@ -46,7 +42,8 @@ faction_succ_seniority = {
 
 			OR = {
 				year >= 1350
-				primary_title = { is_tribal_type_title = no }
+				has_horde_culture = no
+
 				NAND = {
 					culture = ROOT
 					religion = ROOT
@@ -71,7 +68,10 @@ faction_succ_seniority = {
 				liege = {
 					OR = {
 						is_council_content = no
-						NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
 					}
 				}
 			}
@@ -80,6 +80,8 @@ faction_succ_seniority = {
 		trigger_if = {
 			limit = {
 				# If affected by a Crown Law title
+				NOT = { has_dlc = "Conclave" }
+
 				crownlaw_title = {
 					always = yes
 				}
@@ -123,6 +125,7 @@ faction_succ_seniority = {
 
 		NOR = {
 			has_law = succ_seniority
+
 			AND = {
 				has_law = succession_voting_power_1
 				OR = {
@@ -152,30 +155,35 @@ faction_succ_seniority = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
+			NOT = { religion_group = muslim }
+			independent = no
 			is_adult = yes
 			prisoner = no
+			is_incapable = no
 
 			NOR = {
-				is_incapable = yes
-				religion_group = muslim
 				in_faction = faction_succ_primogeniture
 				in_faction = faction_succ_feudal_elective
 				in_faction = faction_succ_gavelkind
 			}
 
-			OR = {
-				NOT = { has_dlc = "Conclave" }
-				is_voter = no
-				is_nomadic = yes
-				is_tribal = yes
+			trigger_if = {
+				limit = { has_dlc = "Conclave" }
 
-				liege = {
-					NOR = {
-						is_council_content = yes
-						primary_title = { has_law = war_voting_power_1 }
+				OR = {
+					is_voter = no
+					is_nomadic = yes
+					is_tribal = yes
+
+					liege = {
+						OR = {
+							is_council_content = no
+
+							primary_title = {
+								NOT = { has_law = war_voting_power_1 }
+							}
+						}
 					}
 				}
 			}
@@ -186,40 +194,69 @@ faction_succ_seniority = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0
+		trigger = {
+			would_be_heir_under_law = {
+				who = FROM
+				law = seniority
+			}
+
 			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
+				prisoner = no
+				preparing_invasion = no
+				NOT = { has_character_modifier = in_seclusion }
+
+				# To stay in the faction
+				trigger_if = {
+					limit = { leads_faction = faction_succ_seniority }
+
+					opinion = {
+						who = liege
+						value < 75
+					}
+				}
+				# To start the faction
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+
+				trigger_if = {
+					limit = {
+						OR = {
+							trait = envious
+							trait = deceitful
+							trait = ambitious
+						}
+					}
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 25
+					}
 				}
 			}
-		}
 
-		modifier = {
-			factor = 0
 			holder_scope = {
-				any_spouse = { character = FROM }
+				NOT = { is_married = FROM }
 			}
-		}
 
-		modifier = {
-			factor = 0
 			current_heir = {
-				character = FROM
+				NOT = { character = FROM }
 			}
-		}
-
-		modifier = {
-			factor = 0
-			NOT = { would_be_heir_under_law = { who = FROM law = seniority } }
 
 		#	heir_under_seniority_law = {
-		#		OR = {
+		#		NOR = {
 		#			ROOT = { current_heir = { character = PREV } }
 		#			FROM = {
 		#				opinion_diff = {
-		#					first = LIEGE
+		#					first = liege
 		#					second = PREV
 		#					value = -25 # I don't like the pretender enough
 		#					as_if_liege = yes
@@ -229,92 +266,62 @@ faction_succ_seniority = {
 		#	}
 		}
 
-		modifier = {
-			factor = 0
-			FROM = {
-				OR = {
-					AND = {
-						NOT = { leads_faction = faction_succ_seniority }
-						opinion = { who = LIEGE value >= 50 }
-					}
-					AND = {
-						leads_faction = faction_succ_seniority
-						opinion = { who = LIEGE value >= 75 }
-					}
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOT = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { pacifist = yes }
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			holder_scope = {
 				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < 0 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < 0
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -323,55 +330,55 @@ faction_succ_seniority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -384,7 +391,145 @@ faction_succ_seniority = {
 	membership = {
 		factor = 1
 
-		modifier = {
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOR = {
+				has_character_modifier = faction_succ_seniority_ultimatum_timer
+
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
+				}
+			}
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						in_faction = faction_succ_feudal_elective
+						in_faction = faction_succ_primogeniture
+						in_faction = faction_succ_gavelkind
+
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+
+						liege = {
+							year < 1350
+							has_horde_culture = yes
+							culture = ROOT
+							religion = ROOT
+						}
+
+						# To stay in the faction
+						trigger_if = {
+							limit = { in_faction = faction_succ_seniority }
+
+							opinion = {
+								who = liege
+								value >= 75
+							}
+						}
+						# To join the faction
+						trigger_else = {
+							opinion = {
+								who = liege
+								value >= 50
+							}
+						}
+
+						FROM = { # Remember: the faction leader is also the person who would inherit under this law
+							liege = {
+								any_demesne_title = {
+									OR = {
+										is_primary_holder_title = yes
+										higher_tier_than = DUKE
+									}
+									ROOT = {
+										primary_title = {
+											de_jure_liege_or_above = PREVPREV
+										}
+									}
+									any_claimant = {
+										religion = ROOT
+
+										ROOT = {
+											opinion_diff = {
+												first = PREV
+												second = liege
+												value >= 10
+												as_if_liege = yes
+											}
+										}
+									}
+								}
+							}
+						}
+
+						FROMFROM = {
+							heir_under_seniority_law = {
+								ROOT = {
+									# To stay in the faction
+									trigger_if = {
+										limit = { in_faction = faction_succ_seniority }
+
+										opinion_diff = {
+											first = liege
+											second = PREV
+											value >= 10
+											as_if_liege = yes
+										}
+									}
+									# To join the faction
+									trigger_else = {
+										opinion_diff = {
+											first = liege
+											second = PREV
+											value >= -10 # I don't like the pretender enough
+											as_if_liege = yes
+										}
+									}
+								}
+							}
+						}
+
+						trigger_if = {
+							limit = {
+								OR = {
+									trait = envious
+									trait = deceitful
+									trait = ambitious
+								}
+							}
+							opinion = {
+								who = liege
+								value >= 50
+							}
+						}
+						trigger_else = {
+							opinion = {
+								who = liege
+								value >= 25
+							}
+						}
+					}
+				}
+
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
+				}
+			}
+		}
+
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -394,218 +539,31 @@ faction_succ_seniority = {
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				in_faction = faction_succ_feudal_elective
-				in_faction = faction_succ_primogeniture
-				in_faction = faction_succ_gavelkind
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_succ_seniority_ultimatum_timer
-		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			ROOT = {
 				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			trigger_if = {
-				limit = { in_faction = faction_succ_seniority }
-				opinion = { who = LIEGE value >= 75 }
-			}
-			trigger_else = {
-				opinion = { who = LIEGE value >= 50 }
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-			FROM = { # Remember: the faction leader is also the person who would inherit under this law
-				liege = {
-					any_demesne_title = {
-						OR = {
-							is_primary_holder_title = yes
-							higher_tier_than = DUKE
-						}
-						ROOT = {
-							primary_title = {
-								de_jure_liege_or_above = PREVPREV
-							}
-						}
-						any_claimant = {
-							religion = ROOT
-							opinion_diff = {
-								first = ROOT
-								second = LIEGE
-								value >= 10 # I like the Claimant more than the current ruler
-								as_if_liege = yes
-							}
-						}
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
 					}
 				}
 			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
 		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				heir_under_seniority_law = {
-					ROOT = {
-						trigger_if = {
-							limit = { in_faction = faction_succ_seniority }
-							opinion_diff = {
-								first = LIEGE
-								second = PREV
-								value >= 10
-								as_if_liege = yes
-							}
-						}
-						trigger_else = {
-							opinion_diff = {
-								first = LIEGE
-								second = PREV
-								value >= -10 # I don't like the pretender enough
-								as_if_liege = yes
-							}
-						}
-					}
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 25 }
-			NOR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 50 }
-			OR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			FROMFROM = {
 				heir_under_seniority_law = {
 					ROOT = {
 						opinion_diff = {
 							first = PREV
-							second = LIEGE
+							second = liege
 							value >= 25
 							as_if_liege = yes
 						}
@@ -613,8 +571,7 @@ faction_succ_seniority = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -624,7 +581,7 @@ faction_succ_seniority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -634,7 +591,7 @@ faction_succ_seniority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -644,7 +601,7 @@ faction_succ_seniority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -654,7 +611,7 @@ faction_succ_seniority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -667,55 +624,55 @@ faction_succ_seniority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -729,6 +686,7 @@ faction_succ_seniority = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_succ_seniority
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -751,24 +709,20 @@ faction_succ_primogeniture = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		NOT = { religion_group = muslim }
+		higher_tier_than = BARON
 		is_adult = yes
+		independent = no
+		prisoner = no
+		is_incapable = no
+		holy_order = no
 
 		NOR = {
-			is_incapable = yes
-			religion_group = muslim
 			in_faction = faction_succ_seniority
 			in_faction = faction_succ_feudal_elective
 			in_faction = faction_succ_gavelkind
 			has_character_modifier = faction_succ_primogeniture_ultimatum_timer
-		}
-
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
 		}
 
 		liege = {
@@ -777,7 +731,8 @@ faction_succ_primogeniture = {
 
 			OR = {
 				year >= 1350
-				primary_title = { is_tribal_type_title = no }
+				has_horde_culture = yes
+
 				NAND = {
 					culture = ROOT
 					religion = ROOT
@@ -802,7 +757,10 @@ faction_succ_primogeniture = {
 				liege = {
 					OR = {
 						is_council_content = no
-						NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
 					}
 				}
 			}
@@ -811,6 +769,8 @@ faction_succ_primogeniture = {
 		trigger_if = {
 			limit = {
 				# If affected by a Crown Law title
+				NOT = { has_dlc = "Conclave" }
+
 				crownlaw_title = {
 					always = yes
 				}
@@ -852,20 +812,20 @@ faction_succ_primogeniture = {
 
 		NOR = {
 			has_law = succ_primogeniture
-			AND = {
-				has_law = succession_voting_power_1
-				has_law = succ_feudal_elective
-			}
-			AND = {
-				has_law = succession_voting_power_1
-				has_law = succ_hre_elective
+
+			trigger_if = {
+				limit = { has_law = succession_voting_power_1 }
+
+				OR = {
+					has_law = succ_feudal_elective
+					has_law = succ_hre_elective
+				}
 			}
 		}
 
 		holder_scope = {
 			NOR = {
 				any_war = {
-					war_title = ROOT
 					using_cb = change_primogeniture_succession_law
 				}
 
@@ -882,15 +842,14 @@ faction_succ_primogeniture = {
 	# FROM = target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
+			NOT = { religion_group = muslim }
 			is_adult = yes
+			independent = no
 			prisoner = no
+			is_incapable = no
 
 			NOR = {
-				is_incapable = yes
-				religion_group = muslim
 				in_faction = faction_succ_seniority
 				in_faction = faction_succ_feudal_elective
 				in_faction = faction_succ_gavelkind
@@ -907,7 +866,10 @@ faction_succ_primogeniture = {
 					liege = {
 						OR = {
 							is_council_content = no
-							NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+							primary_title = {
+								NOT = { has_law = war_voting_power_1 }
+							}
 						}
 					}
 				}
@@ -919,117 +881,119 @@ faction_succ_primogeniture = {
 	chance = {
 		factor = 1
 
-		modifier = {
+		trigger = {
+			would_be_heir_under_law = {
+				who = FROM
+				law = primogeniture
+			}
+
+			FROM = {
+				prisoner = no
+				preparing_invasion = no
+				NOT = { has_character_modifier = in_seclusion }
+
+				# To stay in the faction
+				trigger_if = {
+					limit = { leads_faction = faction_succ_primogeniture }
+
+					opinion = {
+						who = liege
+						value < 75
+					}
+				}
+				# To join the faction
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+
+				trigger_if = {
+					limit = {
+						OR = {
+							trait = envious
+							trait = deceitful
+							trait = ambitious
+						}
+					}
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 25
+					}
+				}
+			}
+
+			holder_scope = {
+				NOT = { is_married = FROM }
+			}
+
+			current_heir = {
+				NOT = { character = FROM }
+			}
+		}
+
+		mult_modifier = {
 			factor = 0.2
 			FROM = { pacifist = yes }
 		}
 
-		modifier = {
-			factor = 0
-			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		modifier = {
-			factor = 0
-			current_heir = {
-				character = FROM
-			}
-		}
-
-		modifier = {
-			factor = 0
-			NOT = { would_be_heir_under_law = { who = FROM law = primogeniture } }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				trigger_if = {
-					limit = { leads_faction = faction_succ_primogeniture }
-					opinion = { who = LIEGE value >= 75 }
-				}
-				trigger_else = {
-					opinion = { who = LIEGE value >= 50 }
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			holder_scope = {
 				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < 0 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < 0
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -1038,55 +1002,55 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -1099,7 +1063,152 @@ faction_succ_primogeniture = {
 	membership = {
 		factor = 1
 
-		modifier = {
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOR = {
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
+				}
+				has_character_modifier = faction_succ_primogeniture_ultimatum_timer
+			}
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						in_faction = faction_succ_feudal_elective
+						in_faction = faction_succ_seniority
+						in_faction = faction_succ_gavelkind
+
+						liege = {
+							year < 1350
+							has_horde_culture = yes
+							culture = ROOT
+							religion = ROOT
+						}
+
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+
+						FROMFROM = {
+							heir_under_primogeniture_law = {
+								ROOT = {
+									# To stay in the faction
+									trigger_if = {
+										limit = { in_faction = faction_succ_primogeniture }
+
+										opinion_diff = {
+											first = liege
+											second = PREV
+											value >= 10
+											as_if_liege = yes
+										}
+									}
+									# To join the faction
+									trigger_else = {
+										opinion_diff = {
+											first = liege
+											second = PREV
+											value >= -10 # I don't like the pretender enough
+											as_if_liege = yes
+										}
+									}
+								}
+							}
+						}
+
+						# To stay in the faction
+						trigger_if = {
+							limit = { in_faction = faction_succ_primogeniture }
+
+							opinion = {
+								who = liege
+								value >= 75
+							}
+						}
+						# To join the faction
+						trigger_else = {
+							opinion = {
+								who = liege
+								value >= 50
+							}
+						}
+
+						trigger_if = {
+							limit = {
+								OR = {
+									trait = envious
+									trait = deceitful
+									trait = ambitious
+								}
+							}
+
+							opinion = {
+								who = liege
+								value >= 50
+							}
+						}
+						trigger_else = {
+							opinion = {
+								who = liege
+								value >= 25
+							}
+						}
+
+						# Try to exclude people who should rather support a claimant
+						# Remember: the faction leader is also the person who would inherit under this law
+						AND = {
+							NAND = {
+								culture = ROOT
+								religion = ROOT
+							}
+							liege = {
+								any_demesne_title = {
+									OR = {
+										is_primary_holder_title = yes
+										higher_tier_than = DUKE
+									}
+
+									ROOT = {
+										primary_title = {
+											de_jure_liege_or_above = PREVPREV
+										}
+									}
+
+									any_claimant = {
+										culture = ROOT
+										religion = ROOT
+									}
+								}
+							}
+						}
+					}
+				}
+
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
+				}
+			}
+		}
+
+		mult_modifier = {
+			factor = 1000
+			has_opinion_modifier = {
+				who = FROM
+				modifier = opinion_coerced_into_joining_faction
+			}
+		}
+		mult_modifier = {
 			factor = 0.5
 			ROOT = {
 				liege = {
@@ -1107,8 +1216,7 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -1118,212 +1226,14 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				in_faction = faction_succ_feudal_elective
-				in_faction = faction_succ_seniority
-				in_faction = faction_succ_gavelkind
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_succ_primogeniture_ultimatum_timer
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				heir_under_primogeniture_law = {
-					ROOT = {
-						trigger_if = {
-							limit = { in_faction = faction_succ_primogeniture }
-							opinion_diff = {
-								first = LIEGE
-								second = PREV
-								value >= 10
-								as_if_liege = yes
-							}
-						}
-						trigger_else = {
-							opinion_diff = {
-								first = LIEGE
-								second = PREV
-								value >= -10 # I don't like the pretender enough
-								as_if_liege = yes
-							}
-						}
-					}
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-
-			trigger_if = {
-				limit = { in_faction = faction_succ_primogeniture }
-				opinion = { who = LIEGE value = 75 }
-			}
-			trigger_else = {
-				opinion = { who = LIEGE value = 50 }
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-			FROM = { # Remember: the faction leader is also the person who would inherit under this law
-				OR = {
-					NOT = { culture = ROOT }
-					NOT = { religion = ROOT }
-				}
-				liege = {
-					any_demesne_title = {
-						OR = {
-							is_primary_holder_title = yes
-							higher_tier_than = DUKE
-						}
-
-						ROOT = {
-							primary_title = {
-								de_jure_liege_or_above = PREVPREV
-							}
-						}
-
-						any_claimant = {
-							culture = ROOT
-							religion = ROOT
-						}
-					}
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 25 }
-			NOR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 50 }
-			OR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 1000
-			has_opinion_modifier = {
-				who = FROM
-				modifier = opinion_coerced_into_joining_faction
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			FROMFROM = {
 				heir_under_primogeniture_law = {
 					ROOT = {
 						opinion_diff = {
 							first = PREV
-							second = LIEGE
+							second = liege
 							value >= 25
 							as_if_liege = yes
 						}
@@ -1331,8 +1241,7 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -1342,7 +1251,7 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -1352,7 +1261,7 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -1362,7 +1271,7 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -1372,7 +1281,7 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -1385,55 +1294,55 @@ faction_succ_primogeniture = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -1447,6 +1356,7 @@ faction_succ_primogeniture = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_succ_primogeniture
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -1469,33 +1379,30 @@ faction_succ_gavelkind = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		higher_tier_than = BARON
+		NOT = { religion_group = muslim }
 		is_adult = yes
+		prisoner = no
+		independent = no
+		is_incapable = no
+		holy_order = no
 
 		NOR = {
-			is_incapable = yes
-			religion_group = muslim
 			in_faction = faction_succ_seniority
 			in_faction = faction_succ_primogeniture
 			in_faction = faction_succ_feudal_elective
 			has_character_modifier = faction_succ_gavelkind_ultimatum_timer
 		}
 
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
-		}
-
 		liege = {
-			is_vice_royalty = no
 			is_feudal = yes
+			is_vice_royalty = no
 
 			OR = {
 				year >= 1350
-				primary_title = { is_tribal_type_title = no }
+				has_horde_culture = no
+
 				NAND = {
 					culture = ROOT
 					religion = ROOT
@@ -1520,7 +1427,10 @@ faction_succ_gavelkind = {
 				liege = {
 					OR = {
 						is_council_content = no
-						NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
 					}
 				}
 			}
@@ -1529,6 +1439,8 @@ faction_succ_gavelkind = {
 		trigger_if = {
 			limit = {
 				# If affected by a Crown Law title
+				NOT = { has_dlc = "Conclave" }
+
 				crownlaw_title = {
 					always = yes
 				}
@@ -1570,6 +1482,7 @@ faction_succ_gavelkind = {
 
 		NOR = {
 			has_law = succ_gavelkind
+
 			AND = {
 				has_law = succession_voting_power_1
 				OR = {
@@ -1599,15 +1512,14 @@ faction_succ_gavelkind = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
+			NOT = { religion_group = muslim }
+			independent = no
 			is_adult = yes
 			prisoner = no
+			is_incapable = no
 
 			NOR = {
-				is_incapable = yes
-				religion_group = muslim
 				in_faction = faction_succ_seniority
 				in_faction = faction_succ_primogeniture
 				in_faction = faction_succ_feudal_elective
@@ -1624,7 +1536,10 @@ faction_succ_gavelkind = {
 					liege = {
 						OR = {
 							is_council_content = no
-							NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+							primary_title = {
+								NOT = { has_law = war_voting_power_1 }
+							}
 						}
 					}
 				}
@@ -1636,50 +1551,101 @@ faction_succ_gavelkind = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0.2
-			FROM = { pacifist = yes }
-		}
-
-		modifier = {
-			factor = 0
+		trigger = {
 			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
+				prisoner = no
+				NOT = { has_character_modifier = in_seclusion }
+				preparing_invasion = no
+
+				# To keep leading the faction
+				trigger_if = {
+					limit = { leads_faction = faction_succ_gavelkind }
+
+					opinion = {
+						who = liege
+						value < 75
+					}
+				}
+				# To create the faction
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+
+				trigger_if = {
+					limit = {
+						OR = {
+							trait = envious
+							trait = deceitful
+							trait = ambitious
+						}
+					}
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 25
+					}
 				}
 			}
-		}
 
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		# Not for the current heir
-		modifier = {
-			factor = 0
 			current_heir = {
-				character = FROM
+				NOT = { character = FROM }
 			}
-		}
 
-		modifier = {
-			factor = 0
-			OR = {
-				has_law = succ_feudal_elective
-				has_law = succ_hre_elective
+			holder_scope = {
+				NOT = { is_married = FROM }
+
+				# Try to exclude people who should rather support a claimant
+				trigger_if = {
+					limit = {
+						NAND = {
+							culture = FROM
+							religion = FROM
+						}
+					}
+
+					any_demesne_title = {
+						OR = {
+							is_primary_holder_title = yes
+							higher_tier_than = DUKE
+						}
+
+						FROM = {
+							primary_title = {
+								de_jure_liege_or_above = PREVPREV
+							}
+						}
+
+						any_claimant = {
+							culture = FROM
+							religion = FROM
+						}
+					}
+				}
 			}
-			NOT = {
+
+			trigger_if = {
+				limit = {
+					OR = {
+						has_law = succ_feudal_elective
+						has_law = succ_hre_elective
+					}
+				}
+
 				holder_scope = {
-					dynasty = FROM
+					NOT = { dynasty = FROM }
 				}
 			}
 		}
 
-	#	modifier = { # Removed, we want Vassals to start Gavelkind factions in general
+	#	mult_modifier = { # Removed, we want Vassals to start Gavelkind factions in general
 	#		factor = 0
 	#		# Is not a child of the title holder, and no need to split the demesne
 	#		holder_scope = {
@@ -1702,91 +1668,24 @@ faction_succ_gavelkind = {
 	#		}
 	#	}
 
-		modifier = {
+		mult_modifier = {
+			factor = 0.2
+			FROM = { pacifist = yes }
+		}
+		mult_modifier = {
 			factor = 0.5
 			holder_scope = {
 				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
 			}
 		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-			holder_scope = {
-				NAND = {
-					culture = FROM
-					religion = FROM
-				}
-
-				any_demesne_title = {
-					OR = {
-						is_primary_holder_title = yes
-						higher_tier_than = DUKE
-					}
-
-					FROM = {
-						primary_title = {
-							de_jure_liege_or_above = PREVPREV
-						}
-					}
-
-					any_claimant = {
-						culture = FROM
-						religion = FROM
-					}
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				trigger_if = {
-					limit = { leads_faction = faction_succ_gavelkind }
-					opinion = { who = LIEGE value >= 75 }
-				}
-				trigger_else = {
-					opinion = { who = LIEGE value >= 50 }
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 4
 			FROM = {
 				is_voter = yes
 
 				liege = {
 					has_council = yes
+
 					primary_title = {
 						NOR = {
 							has_law = law_voting_power_1
@@ -1801,42 +1700,54 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < 0 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < 0
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { is_pretender = yes }
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -1845,55 +1756,55 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -1906,15 +1817,121 @@ faction_succ_gavelkind = {
 	membership = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			ROOT = {
-				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOR = {
+				has_character_modifier = faction_succ_gavelkind_ultimatum_timer
+
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
+				}
+			}
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						in_faction = faction_succ_feudal_elective
+						in_faction = faction_succ_seniority
+						in_faction = faction_succ_primogeniture
+
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+
+						liege = {
+							year < 1350
+							has_horde_culture = yes
+							culture = ROOT
+							religion = ROOT
+						}
+
+						# To stay in the faction
+						trigger_if = {
+							limit = { in_faction = faction_succ_gavelkind }
+
+							opinion_diff = {
+								first = liege
+								second = FROM
+								value >= 25
+								as_if_liege = yes
+							}
+						}
+						# To join the faction
+						trigger_else = {
+							opinion_diff = {
+								first = liege
+								second = FROM
+								value >= 10 # I like my liege rather a lot more than the faction leader
+								as_if_liege = yes
+							}
+						}
+
+						# To stay in the faction
+						trigger_if = {
+							limit = { in_faction = faction_succ_gavelkind }
+
+							opinion = {
+								who = liege
+								value >= 75
+							}
+						}
+						# To join the faction
+						trigger_else = {
+							opinion = {
+								who = liege
+								value >= 50
+							}
+						}
+
+						trigger_if = {
+							limit = {
+								OR = {
+									trait = envious
+									trait = deceitful
+									trait = ambitious
+								}
+							}
+							opinion = {
+								who = liege
+								value < 50
+							}
+						}
+						trigger_else = {
+							opinion = {
+								who = liege
+								value < 25
+							}
+						}
+					}
+				}
+
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
 				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
+			factor = 0.5
+			ROOT = {
+				liege = {
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
+					}
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -1924,163 +1941,13 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				in_faction = faction_succ_feudal_elective
-				in_faction = faction_succ_seniority
-				in_faction = faction_succ_primogeniture
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-
-			trigger_if = {
-				limit = { in_faction = faction_succ_gavelkind }
-				opinion_diff = {
-					first = LIEGE
-					second = FROM
-					value >= 25
-					as_if_liege = yes
-				}
-			}
-			trigger_else = {
-				opinion_diff = {
-					first = LIEGE
-					second = FROM
-					value >= 10 # I like my liege rather a lot more than the faction leader
-					as_if_liege = yes
-				}
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_succ_gavelkind_ultimatum_timer
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-
-			trigger_if = {
-				limit = { in_faction = faction_succ_gavelkind }
-				opinion = { who = LIEGE value >= 75 }
-			}
-			trigger_else = {
-				opinion = { who = LIEGE value >= 50 }
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 25 }
-			NOR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 50 }
-			OR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 4
 
 			is_voter = yes
 			liege = {
 				has_council = yes
+
 				primary_title = {
 					NOR = {
 						has_law = law_voting_power_1
@@ -2094,26 +1961,23 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			opinion_diff = {
 				first = FROM
-				second = LIEGE
+				second = liege
 				value >= 25
 				as_if_liege = yes
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -2123,7 +1987,7 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -2133,7 +1997,7 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -2143,7 +2007,7 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -2153,7 +2017,7 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -2166,55 +2030,55 @@ faction_succ_gavelkind = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -2228,6 +2092,7 @@ faction_succ_gavelkind = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_succ_gavelkind
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -2250,27 +2115,25 @@ faction_succ_feudal_elective = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		higher_tier_than = BARON
+		NOT = { religion_group = muslim }
 		is_adult = yes
+		independent = no
+		prisoner = no
+		is_incapable = no
+		holy_order = no
 
 		NOR = {
-			is_incapable = yes
-			religion_group = muslim
 			in_faction = faction_succ_seniority
 			in_faction = faction_succ_primogeniture
 			in_faction = faction_succ_gavelkind
 			has_character_modifier = faction_succ_feudal_elective_ultimatum_timer
 		}
 
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
-		}
-
 		liege = {
+			is_feudal = yes
+			is_vice_royalty = no
 			NOT = { government = chinese_imperial_government }
 
 			trigger_if = {
@@ -2294,12 +2157,10 @@ faction_succ_feudal_elective = {
 				}
 			}
 
-			is_vice_royalty = no
-			is_feudal = yes
-
 			OR = {
 				year >= 1350
-				primary_title = { is_tribal_type_title = no }
+				has_horde_culture = no
+
 				NAND = {
 					culture = ROOT
 					religion = ROOT
@@ -2322,19 +2183,23 @@ faction_succ_feudal_elective = {
 				liege = {
 					OR = {
 						is_council_content = no
+
 						primary_title = {
-							NOT = { has_law = war_voting_power_1 }
-							title = e_hre
-							has_title_flag = alternate_hre
+							OR = {
+								NOT = { has_law = war_voting_power_1 }
+								title = e_hre
+								has_title_flag = alternate_hre
+							}
 						}
 					}
 				}
 			}
 		}
-
-		trigger_if = {
+		trigger_else_if = {
 			limit = {
 				# If affected by a Crown Law title
+				NOT = { has_dlc = "Conclave" }
+
 				crownlaw_title = {
 					always = yes
 				}
@@ -2380,6 +2245,7 @@ faction_succ_feudal_elective = {
 		NOR = {
 			has_law = succ_feudal_elective
 			has_law = succ_hre_elective
+
 			AND = {
 				has_law = succession_voting_power_1
 				OR = {
@@ -2413,15 +2279,14 @@ faction_succ_feudal_elective = {
 	# Faction member scope (ROOT = joiner, FROM = target)
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
+			NOT = { religion_group = muslim }
+			independent = no
 			is_adult = yes
 			prisoner = no
+			is_incapable = no
 
 			NOR = {
-				is_incapable = yes
-				religion_group = muslim
 				in_faction = faction_succ_seniority
 				in_faction = faction_succ_primogeniture
 				in_faction = faction_succ_gavelkind
@@ -2457,158 +2322,136 @@ faction_succ_feudal_elective = {
 	chance = {
 		factor = 1
 
-		modifier = {
+		trigger = {
+			# If next in line under seniority, create that faction instead
+			NOT = {
+				would_be_heir_under_law = {
+					who = FROM
+					law = seniority
+				}
+			}
+
+			FROM = {
+				prisoner = no
+				preparing_invasion = no
+				NOT = { has_character_modifier = in_seclusion }
+
+				# To keep leading the faction
+				trigger_if = {
+					limit = { leads_faction = faction_succ_feudal_elective }
+
+					opinion = {
+						who = liege
+						value >= 75
+					}
+				}
+				# To creat the faction
+				trigger_else = {
+					opinion = {
+						who = liege
+						value >= 50
+					}
+				}
+
+				trigger_if = {
+					limit = {
+						OR = {
+							trait = envious
+							trait = deceitful
+							trait = ambitious
+						}
+					}
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 25
+					}
+				}
+			}
+
+			# Not for the (spouse of) current heir
+			current_heir = {
+				NOR = {
+					character = FROM
+					is_married = FROM
+				}
+			}
+
+			# Not for spouse/children of the current ruler
+			holder_scope = {
+				NOR = {
+					is_married = FROM
+					is_parent_of = FROM
+				}
+
+				# Try to exclude people who should rather support a claimant
+				trigger_if = {
+					limit = {
+						NAND = {
+							culture = FROM
+							religion = FROM
+						}
+					}
+					NOT = {
+						any_demesne_title = {
+							OR = {
+								is_primary_holder_title = yes
+								higher_tier_than = DUKE
+							}
+
+							FROM = {
+								primary_title = {
+									de_jure_liege_or_above = PREVPREV
+								}
+							}
+
+							any_claimant = {
+								culture = FROM
+								religion = FROM
+							}
+						}
+					}
+				}
+			}
+
+			# Not for dynasty members if under seniority law
+			trigger_if = {
+				limit = { has_law = succ_seniority }
+				holder_scope = {
+					NOT = { dynasty = FROM }
+				}
+			}
+		}
+
+		mult_modifier = {
 			factor = 1.5
 			holder_scope = {
 				primary_title = { title = e_hre }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			holder_scope = {
 				primary_title = { has_title_flag = alternate_hre }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			holder_scope = {
 				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { pacifist = yes }
 		}
 
-		modifier = {
-			factor = 0
-			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		# Not for the current heir
-		modifier = {
-			factor = 0
-			current_heir = {
-				character = FROM
-			}
-		}
-
-		# Not for spouse of current heir
-		modifier = {
-			factor = 0
-			current_heir = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		# Not for children of the present holder
-		modifier = {
-			factor = 0
-			holder_scope = {
-				FROM = {
-					is_child_of = PREV
-				}
-			}
-		}
-
-		# Not for dynasty members if under seniority law
-		modifier = {
-			factor = 0
-			has_law = succ_seniority
-			holder_scope = {
-				dynasty = FROM
-			}
-		}
-
-		# If next in line under seniority, choose that plot instead
-		modifier = {
-			factor = 0
-			would_be_heir_under_law = { who = FROM law = seniority }
-		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-			holder_scope = {
-				NAND = {
-					culture = FROM
-					religion = FROM
-				}
-				any_demesne_title = {
-					OR = {
-						is_primary_holder_title = yes
-						higher_tier_than = DUKE
-					}
-
-					FROM = {
-						primary_title = {
-							de_jure_liege_or_above = PREVPREV
-						}
-					}
-
-					any_claimant = {
-						culture = FROM
-						religion = FROM
-					}
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				trigger_if = {
-					limit = { leads_faction = faction_succ_feudal_elective }
-					opinion = { who = LIEGE value >= 75 }
-				}
-				trigger_else = {
-					opinion = { who = LIEGE value >= 50 }
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.7
 			FROM = {
 				liege = {
@@ -2616,18 +2459,22 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.7
 			FROM = {
 				NOR = {
-					has_opinion_modifier = { who = LIEGE modifier = opinion_evil_tyrant }
-					has_opinion_modifier = { who = LIEGE modifier = opinion_tyrant }
+					has_opinion_modifier = {
+						who = liege
+						modifier = opinion_evil_tyrant
+					}
+					has_opinion_modifier = {
+						who = liege
+						modifier = opinion_tyrant
+					}
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 3
 			FROM = {
 				liege = {
@@ -2636,42 +2483,55 @@ faction_succ_feudal_elective = {
 				is_voter = yes
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < 0 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < 0
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { is_pretender = yes }
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -2680,55 +2540,55 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -2741,15 +2601,122 @@ faction_succ_feudal_elective = {
 	membership = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			ROOT = {
-				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+		trigger = {
+			prisoner = no
+			is_incapable = no
+			is_adult = yes
+			is_landed = yes
+			preparing_invasion = no
+
+			NOR = {
+				has_character_modifier = faction_succ_feudal_elective_ultimatum_timer
+
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
+				}
+			}
+
+			trigger_if = {
+				limit = {
+					NOT = {
+						has_opinion_modifier = {
+							who = FROM
+							modifier = opinion_coerced_into_joining_faction
+						}
+					}
+				}
+
+				NOR = {
+					in_faction = faction_succ_seniority
+					in_faction = faction_succ_primogeniture
+					in_faction = faction_succ_gavelkind
+
+					FROMFROM = {
+						current_heir = {
+							character = ROOT
+						}
+					}
+
+					# To stay in the faction
+					trigger_if = {
+						limit = { in_faction = faction_succ_feudal_elective }
+
+						opinion_diff = {
+							first = liege
+							second = FROM
+							value >= 25
+							as_if_liege = yes
+						}
+					}
+					# To join the faction
+					trigger_else = {
+						opinion_diff = {
+							first = liege
+							second = FROM
+							value >= 10 # I like my liege rather a lot more than the faction leader
+							as_if_liege = yes
+						}
+					}
+
+					# To stay in the faction
+					trigger_if = {
+						limit = { in_faction = faction_succ_feudal_elective }
+
+						opinion = {
+							who = liege
+							value >= 75
+						}
+					}
+					# To join the faction
+					trigger_else = {
+						opinion = {
+							who = liege
+							value >= 50
+						}
+					}
+
+					liege = {
+						year < 1350
+						has_horde_culture = yes
+						culture = ROOT
+						religion = ROOT
+					}
+
+					trigger_if = {
+						limit = {
+							OR = {
+								trait = envious
+								trait = deceitful
+								trait = ambitious
+							}
+						}
+						opinion = {
+							who = liege
+							value >= 50
+						}
+					}
+					trigger_else = {
+						opinion = {
+							who = liege
+							value >= 25
+						}
+					}
 				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
+			factor = 0.5
+			ROOT = {
+				liege = {
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
+					}
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -2759,199 +2726,49 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				in_faction = faction_succ_seniority
-				in_faction = faction_succ_primogeniture
-				in_faction = faction_succ_gavelkind
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-
-			trigger_if = {
-				limit = { in_faction = faction_succ_feudal_elective }
-				opinion_diff = {
-					first = LIEGE
-					second = FROM
-					value = 25
-					as_if_liege = yes
-				}
-			}
-			trigger_else = {
-				opinion_diff = {
-					first = LIEGE
-					second = FROM
-					value = 10 # I like my liege rather a lot more than the faction leader
-					as_if_liege = yes
-				}
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			trigger_if = {
-				limit = { in_faction = faction_succ_feudal_elective }
-				opinion = { who = LIEGE value >= 75 }
-			}
-			trigger_else = {
-				opinion = { who = LIEGE value >= 50 }
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_succ_feudal_elective_ultimatum_timer
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 25 }
-			NOR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 50 }
-			OR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.7
 			liege = {
 				has_law = succ_gavelkind
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.7
 			NOR = {
-				has_opinion_modifier = { who = LIEGE modifier = opinion_evil_tyrant }
-				has_opinion_modifier = { who = LIEGE modifier = opinion_tyrant }
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_evil_tyrant
+				}
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_tyrant
+				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 3
 			liege = {
 				has_council = yes
 			}
 			is_voter = yes
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			opinion_diff = {
 				first = FROM
-				second = LIEGE
+				second = liege
 				value >= 25
 				as_if_liege = yes
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -2961,7 +2778,7 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -2971,7 +2788,7 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -2981,7 +2798,7 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -2991,7 +2808,7 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -3004,55 +2821,55 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -3069,6 +2886,7 @@ faction_succ_feudal_elective = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_succ_feudal_elective
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -3098,23 +2916,21 @@ faction_lower_crown_authority = {
 		independent = no
 		is_landed = yes
 		is_adult = yes
+		is_incapable = no
 
 		primary_title = {
 			holy_order = no
 			higher_tier_than = BARON
 		}
 
-		NOR = {
-			is_incapable = yes
-			has_character_modifier = faction_lower_CA_ultimatum_timer
-		}
+		NOT = { has_character_modifier = faction_lower_CA_ultimatum_timer }
 
 		liege = {
 			is_feudal = yes
 
 			OR = {
 				year >= 1350
-				primary_title = { is_tribal_type_title = no }
+				has_horde_culture = no
 
 				NAND = {
 					culture = ROOT
@@ -3134,10 +2950,6 @@ faction_lower_crown_authority = {
 	allow = {
 		higher_tier_than = DUKE
 
-		holder_scope = {
-			independent = yes
-		}
-
 		OR = {
 			is_primary_holder_title = yes
 			is_titular = no
@@ -3146,6 +2958,8 @@ faction_lower_crown_authority = {
 		NOT = { has_law = crown_authority_0 }
 
 		holder_scope = {
+			independent = yes
+
 			NOR = {
 				any_war = {
 					war_title = ROOT
@@ -3165,16 +2979,12 @@ faction_lower_crown_authority = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			NOR = {
-				has_dlc = "Conclave"
-				is_incapable = yes
-			}
-
-			is_ruler = yes
-			independent = no
+			NOT = { has_dlc = "Conclave" }
 			is_landed = yes
+			independent = no
 			is_adult = yes
 			prisoner = no
+			is_incapable = no
 		}
 	}
 
@@ -3182,154 +2992,149 @@ faction_lower_crown_authority = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
+		trigger = {
+			FROM = {
+				crownlaw_title = { title = ROOT }
+
+				prisoner = no
+				NOT = { has_character_modifier = in_seclusion }
+				preparing_invasion = no
+
+				trigger_if = {
+					limit = {
+						OR = {
+							trait = envious
+							trait = deceitful
+							trait = ambitious
+						}
+					}
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 25
+					}
+				}
+			}
+
+			current_heir = {
+				NOT = { character = FROM }
+			}
+
 			holder_scope = {
-				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+				NOT = { is_married = FROM }
+
+				# Try to exclude people who should rather support a claimant
+				trigger_if = {
+					limit = {
+						NAND = {
+							culture = FROM
+							religion = FROM
+						}
+					}
+
+					NOT = {
+						any_demesne_title = {
+							OR = {
+								is_primary_holder_title = yes
+								higher_tier_than = DUKE
+							}
+							FROM = {
+								primary_title = {
+									de_jure_liege_or_above = PREVPREV
+								}
+							}
+							any_claimant = {
+								culture = FROM
+								religion = FROM
+							}
+						}
+					}
+				}
+
+				FROM = {
+					NOT = {
+						has_opinion_modifier = {
+							who = PREV
+							modifier = opinion_lowered_crown_authority
+						}
+					}
+				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
+			factor = 0.5
+			holder_scope = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_less_factions
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 0.2
 			FROM = { pacifist = yes }
 		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		modifier = {
-			factor = 0
-			current_heir = {
-				character = FROM
-			}
-		}
-
-		modifier = {
-			factor = 0
-			NOT = { FROM = { crownlaw_title = { title = ROOT } } }
-		}
-
-		modifier = {
-			factor = 0
-			holder_scope = {
-				FROM = {
-					has_opinion_modifier = { who = PREV modifier = opinion_lowered_crown_authority }
-				}
-			}
-		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-			holder_scope = {
-				NAND = {
-					culture = FROM
-					religion = FROM
-				}
-
-				any_demesne_title = {
-					OR = {
-						is_primary_holder_title = yes
-						higher_tier_than = DUKE
-					}
-					FROM = {
-						primary_title = {
-							de_jure_liege_or_above = PREVPREV
-						}
-					}
-					any_claimant = {
-						culture = FROM
-						religion = FROM
-					}
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			has_law = crown_authority_1
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_law = crown_authority_3
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.25
 			has_law = crown_authority_4
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -10 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -10
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -3338,55 +3143,55 @@ faction_lower_crown_authority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -3399,15 +3204,69 @@ faction_lower_crown_authority = {
 	membership = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			ROOT = {
-				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+		trigger = {
+			prisoner = no
+			is_incapable = no
+			is_adult = yes
+			is_landed = yes
+			preparing_invasion = no
+			NOT = { has_character_modifier = faction_lower_CA_ultimatum_timer }
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						# I'm the current heir
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+
+						# Doesn't affect me personally
+						crownlaw_title = {
+							NOT = { title = FROMFROM }
+						}
+
+						# I don't like the faction leader
+						opinion = {
+							who = FROM
+							value >= -40
+						}
+
+						# I like my liege
+						opinion = {
+							who = liege
+							value >= 25
+						}
+
+						liege = {
+							year < 1350
+							has_horde_culture = yes
+							culture = ROOT
+							religion = ROOT
+						}
+					}
+				}
+
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
 				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
+			factor = 0.5
+			ROOT = {
+				liege = {
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
+					}
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -3417,117 +3276,35 @@ faction_lower_crown_authority = {
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			NOR = {
-				crownlaw_title = { title = FROMFROM }
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_lower_CA_ultimatum_timer
-		}
-
-		modifier = {
-			factor = 0
-			NOR = {
-				opinion = { who = FROM value >= -40 }
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 25 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -10 }
+			opinion = {
+				who = liege
+				value < -10
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
+			opinion = {
+				who = liege
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
+			opinion = {
+				who = liege
+				value < -75
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROMFROM = {
 				has_law = crown_authority_1
@@ -3539,20 +3316,19 @@ faction_lower_crown_authority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROMFROM = {
 				has_law = crown_authority_3
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.25
 			FROMFROM = {
 				has_law = crown_authority_4
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -3562,7 +3338,7 @@ faction_lower_crown_authority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -3572,7 +3348,7 @@ faction_lower_crown_authority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -3582,7 +3358,7 @@ faction_lower_crown_authority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -3592,7 +3368,7 @@ faction_lower_crown_authority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -3605,55 +3381,55 @@ faction_lower_crown_authority = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -3662,7 +3438,10 @@ faction_lower_crown_authority = {
 	success = {
 		holder_scope = {
 			FROM = {
-				has_opinion_modifier = { who = PREV modifier = opinion_lowered_crown_authority }
+				has_opinion_modifier = {
+					who = PREV
+					modifier = opinion_lowered_crown_authority
+				}
 			}
 		}
 	}
@@ -3671,6 +3450,7 @@ faction_lower_crown_authority = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_lower_crown_authority
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -3693,41 +3473,15 @@ faction_lower_tribal_organization = {
 
 	# Plotter scope
 	potential = {
+		is_landed = yes
+		higher_tier_than = BARON
+		independent = no
+		is_adult = yes
 		prisoner = no
 		is_ruler = yes
-		independent = no
-		is_landed = yes
-		is_adult = yes
-
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
-		}
-
-		NOR = {
-			is_incapable = yes
-			has_character_modifier = faction_lower_TO_ultimatum_timer
-		}
-
-		OR = {
-			is_tribal = yes
-
-			AND = {
-				has_dlc = "Conclave"
-
-				OR = {
-					is_voter = no
-					is_nomadic = yes
-
-					liege = {
-						OR = {
-							is_council_content = no
-							NOT = { primary_title = { has_law = war_voting_power_1 } }
-						}
-					}
-				}
-			}
-		}
+		is_incapable = no
+		holy_order = no
+		NOT = { has_character_modifier = faction_lower_TO_ultimatum_timer }
 
 		liege = {
 			is_tribal = yes
@@ -3738,13 +3492,34 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
+
+		trigger_if = {
+			limit = { has_dlc = "Conclave" }
+
+			OR = {
+				is_voter = no
+				is_nomadic = yes
+
+				liege = {
+					OR = {
+						is_council_content = no
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
+					}
+				}
+			}
+		}
+		trigger_else = {
+			is_tribal = yes
+		}
 	}
 
 	# Target scope
 	allow = {
 		higher_tier_than = COUNT
 		is_primary_holder_title = yes
-
 		NOT = { has_law = tribal_organization_0 }
 
 		holder_scope = {
@@ -3769,32 +3544,32 @@ faction_lower_tribal_organization = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
 			is_adult = yes
+			independent = no
 			prisoner = no
-
 			is_incapable = no
 
-			OR = {
-				is_tribal = yes
+			trigger_if = {
+				limit = { has_dlc = "Conclave" }
 
-				AND = {
-					has_dlc = "Conclave"
+				OR = {
+					is_voter = no
+					is_nomadic = yes
 
-					OR = {
-						is_voter = no
-						is_nomadic = yes
+					liege = {
+						OR = {
+							is_council_content = no
 
-						liege = {
-							OR = {
-								is_council_content = no
-								NOT = { primary_title = { has_law = war_voting_power_1 } }
+							primary_title = {
+								NOT = { has_law = war_voting_power_1 }
 							}
 						}
 					}
 				}
+			}
+			trigger_else = {
+				is_tribal = yes
 			}
 		}
 	}
@@ -3803,156 +3578,150 @@ faction_lower_tribal_organization = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			holder_scope = {
-				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
-			}
-		}
-		modifier = {
-			factor = 0
-			FROM = { dislike_tribal_organization = no }
-		}
-
-		modifier = {
-			factor = 0.2
-			FROM = { pacifist = yes }
-		}
-
-		modifier = {
-			factor = 0
+		trigger = {
 			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
-				}
-			}
-		}
+				dislike_tribal_organization = yes
+				prisoner = no
+				preparing_invasion = no
+				NOT = { has_character_modifier = in_seclusion }
 
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		modifier = {
-			factor = 0
-			current_heir = {
-				character = FROM
-			}
-		}
-
-		modifier = {
-			factor = 0
-			holder_scope = {
-				FROM = {
-					has_opinion_modifier = { who = PREV modifier = opinion_lowered_tribal_organization }
-				}
-			}
-		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-			holder_scope = {
-				NAND = {
-					culture = FROM
-					religion = FROM
-				}
-
-				any_demesne_title = {
-					OR = {
-						is_primary_holder_title = yes
-						higher_tier_than = COUNT
+				trigger_if = {
+					limit = {
+						OR = {
+							trait = envious
+							trait = deceitful
+							trait = ambitious
+						}
 					}
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 25
+					}
+				}
+			}
 
-					FROM = {
-						primary_title = {
-							de_jure_liege_or_above = PREVPREV
+			holder_scope = {
+				NOT = { is_married = FROM }
+
+				FROM = {
+					NOT = {
+						has_opinion_modifier = {
+							who = PREV
+							modifier = opinion_lowered_tribal_organization
+						}
+					}
+				}
+
+				# Try to exclude people who should rather support a claimant
+				trigger_if = {
+					limit = {
+						NAND = {
+							culture = FROM
+							religion = FROM
 						}
 					}
 
-					any_claimant = {
-						culture = FROM
-						religion = FROM
+					NOT = {
+						any_demesne_title = {
+							OR = {
+								is_primary_holder_title = yes
+								higher_tier_than = COUNT
+							}
+
+							FROM = {
+								primary_title = {
+									de_jure_liege_or_above = PREVPREV
+								}
+							}
+
+							any_claimant = {
+								culture = FROM
+								religion = FROM
+							}
+						}
 					}
 				}
 			}
-		}
 
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOT = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
+			current_heir = {
+				NOT = { character = FROM }
 			}
 		}
 
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
+		mult_modifier = {
+			factor = 0.5
+			holder_scope = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_less_factions
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
+			factor = 0.2
+			FROM = { pacifist = yes }
+		}
+		mult_modifier = {
 			factor = 0.1
 			has_law = tribal_organization_1
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_law = tribal_organization_3
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.25
 			has_law = tribal_organization_4
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -10 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -10
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -3961,55 +3730,55 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -4022,18 +3791,49 @@ faction_lower_tribal_organization = {
 	membership = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			ROOT = {
-				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOR = {
+				has_character_modifier = faction_lower_TO_ultimatum_timer
+
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
 				}
 			}
-		}
-		modifier = {
-			factor = 0
-			dislike_tribal_organization = no
-			NOT = {
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						dislike_tribal_organization = no
+
+						# I'm the current heir
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+
+						# don't like the faction leader
+						opinion = {
+							who = FROM
+							value < -40
+						}
+
+						# I like my liege
+						opinion = {
+							who = liege
+							value >= 25
+						}
+					}
+				}
+
 				has_opinion_modifier = {
 					who = FROM
 					modifier = opinion_coerced_into_joining_faction
@@ -4041,7 +3841,17 @@ faction_lower_tribal_organization = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
+			factor = 0.5
+			ROOT = {
+				liege = {
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
+					}
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -4051,90 +3861,35 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_lower_TO_ultimatum_timer
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = FROM value < -40 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 25 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -10 }
+			opinion = {
+				who = liege
+				value < -10
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
+			opinion = {
+				who = liege
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
+			opinion = {
+				who = liege
+				value < -75
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROMFROM = {
 				has_law = tribal_organization_1
@@ -4146,20 +3901,20 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROMFROM = {
 				has_law = tribal_organization_3
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.25
 			FROMFROM = {
 				has_law = tribal_organization_4
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -4169,7 +3924,7 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -4179,7 +3934,7 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -4189,7 +3944,7 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -4199,7 +3954,7 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -4212,55 +3967,55 @@ faction_lower_tribal_organization = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -4269,7 +4024,10 @@ faction_lower_tribal_organization = {
 	success = {
 		holder_scope = {
 			FROM = {
-				has_opinion_modifier = { who = PREV modifier = opinion_lowered_tribal_organization }
+				has_opinion_modifier = {
+					who = PREV
+					modifier = opinion_lowered_tribal_organization
+				}
 			}
 		}
 	}
@@ -4278,6 +4036,7 @@ faction_lower_tribal_organization = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_lower_tribal_organization
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -4300,34 +4059,34 @@ faction_independence = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		higher_tier_than = BARON
 		is_adult = yes
+		independent = no
+		prisoner = no
+		is_incapable = no
 		mercenary = no
+		holy_order = no
 
 		NOR = {
-			is_incapable = yes
 			has_character_modifier = faction_independence_ultimatum_timer
 			has_landed_title = k_orthodox
 		}
 
-		OR = {
-			ai = yes
-			is_feudal = yes
-			is_tribal = yes
-			is_nomadic = yes
-			higher_tier_than = COUNT
-		}
+		trigger_if = {
+			limit = { ai = no }
 
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
+			OR = {
+				is_feudal = yes
+				is_tribal = yes
+				is_nomadic = yes
+				higher_tier_than = COUNT
+			}
 		}
 
 		liege = {
 			independent = yes
+
 			NOT = {
 				any_war = {
 					using_cb = cb_faction_independence
@@ -4337,25 +4096,20 @@ faction_independence = {
 			# Mongols and Aztecs do not have independence revolt problems before 1350
 			OR = {
 				year >= 1350
-				primary_title = { is_tribal = no }
+				has_horde_culture = no
+
 				NAND = {
 					culture = ROOT
 					religion = ROOT
 				}
-				NOR = {
-					culture = nahuatl
-					culture = mongol
-				}
 			}
 
 			# Not allowed to start factions like this if our capital borders the liege's capital
-			NOT = {
-				capital_scope = {
-					any_neighbor_province = {
-						ROOT = {
-							capital_scope = {
-								province = PREVPREV
-							}
+			capital_scope = {
+				any_neighbor_province = {
+					ROOT = {
+						capital_scope = {
+							NOT = { province = PREVPREV }
 						}
 					}
 				}
@@ -4408,14 +4162,19 @@ faction_independence = {
 	allow = {
 		prisoner = no
 
+		trigger_if = {
+			limit = { is_nomadic = yes }
+
+			clan_opinion = {
+				who = liege
+				value < 0
+			}
+		}
+
 		NOR = {
 			has_opinion_modifier = {
-				who = LIEGE
+				who = liege
 				modifier = opinion_coerced_into_leaving_faction
-			}
-			AND = {
-				is_nomadic = yes
-				clan_opinion = { who = LIEGE value >= 0 }
 			}
 		}
 	}
@@ -4425,13 +4184,11 @@ faction_independence = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
+			independent = no
 			is_adult = yes
 			prisoner = no
 			mercenary = no
-
 			is_incapable = no
 
 			trigger_if = {
@@ -4445,8 +4202,11 @@ faction_independence = {
 					liege = {
 						OR = {
 							is_council_content = no
-							NOT = { primary_title = { has_law = war_voting_power_1 } }
 							has_landed_title = e_china_west_governor
+
+							primary_title = {
+								NOT = { has_law = war_voting_power_1 }
+							}
 						}
 					}
 				}
@@ -4454,7 +4214,13 @@ faction_independence = {
 
 			trigger_if = {
 				limit = { is_nomadic = yes }
-				clan_opinion = { who = LIEGE value < 0 }
+
+				clan_opinion = {
+					who = liege
+					value < 0
+				}
+
+				NOT = { has_blood_oath_with = liege }
 			}
 
 			# No independence factions in merchant republics
@@ -4464,15 +4230,6 @@ faction_independence = {
 					is_merchant_republic = yes
 				}
 			}
-
-			# Can't join factions when in blood oath with liege
-			trigger_if = {
-				limit = { is_nomadic = yes }
-
-				liege = {
-					NOT = { has_blood_oath_with = PREV }
-				}
-			}
 		}
 	}
 
@@ -4480,308 +4237,316 @@ faction_independence = {
 	chance = {
 		factor = 4
 
-		modifier = {
-			factor = 0.5
-			liege = {
-				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
-			}
-		}
-		modifier = {
-			factor = 0.2
-			FROM = { pacifist = yes }
-		}
+		trigger = {
+			war = no
+			preparing_invasion = no
 
-		modifier = {
-			factor = 0
-			FROM = {
+			NOR = {
+				is_heir = liege
 				has_character_modifier = in_seclusion
 			}
-		}
 
-		modifier = {
-			factor = 0
-			war = yes
-		}
+			# Patricians can't leave their republic
+			trigger_if = {
+				limit = { is_patrician = yes }
+				is_merchant_republic = yes
+			}
 
-		modifier = {
-			factor = 0
-			is_patrician = yes
-			is_merchant_republic = no
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				religion = ROOT
-				culture = ROOT
+			trigger_if = {
+				limit = {
+					religion = liege
+					culture = liege
+				}
 
 				OR = {
-					distance = { who = ROOT distance < 100 }
+					trigger_if = {
+						limit = {
+							religion_group = pagan_group
+							is_reformed_religion = no
+						}
 
-					AND = {
-						distance = { who = ROOT distance < 200 }
+						distance = {
+							who = liege
+							value >= 100
+						}
+					}
+					trigger_else = {
+						distance = {
+							who = liege
+							value >= 200
+						}
+					}
 
-						ROOT = {
-							trigger_if = {
-								limit = { religion_group = pagan_group }
-								is_reformed_religion = yes
+					NAND = {
+						de_jure_liege_or_above = liege
+						lower_tier_than = KING
+					}
+				}
+			}
+			trigger_else = {
+				OR = {
+					higher_tier_than = DUKE
+
+					trigger_if = {
+						limit = { religion_group = pagan_group }
+						is_reformed_religion = no
+					}
+
+					NAND = {
+						culture_group = liege
+						religion_group = liege
+
+						OR = {
+							culture = liege
+							religion = liege
+						}
+
+						distance = {
+							who = liege
+							value < 200
+						}
+					}
+				}
+			}
+
+			# Try to exclude people who should rather support a claimant
+			trigger_if = {
+				limit = {
+					lower_tier_than = KING
+
+					NAND = {
+						culture = liege
+						religion = liege
+					}
+				}
+
+				NOT = {
+					liege = {
+						any_demesne_title = {
+							OR = {
+								is_primary_holder_title = yes
+								higher_tier_than = DUKE
+							}
+
+							ROOT = {
+								primary_title = {
+									de_jure_liege_or_above = PREVPREV
+								}
+							}
+
+							any_claimant = {
+								culture = ROOT
+								religion = ROOT
 							}
 						}
 					}
-
-					AND = {
-						de_jure_vassal_or_below = ROOT
-						ROOT = { lower_tier_than = KING }
-					}
 				}
 			}
-		}
 
-		modifier = {
-			factor = 0
-			liege = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			lower_tier_than = KING
-
-			trigger_if = {
-				limit = { religion_group = pagan_group }
-				is_reformed_religion = yes
-			}
-
-			liege = {
-				culture_group = ROOT
-				religion_group = ROOT
-
-				OR = {
-					religion = ROOT
-					culture = ROOT
-				}
-
-				distance = { who = ROOT distance < 200 }
-			}
-		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-			lower_tier_than = KING
-			liege = {
-				NAND = {
-					culture = ROOT
-					religion = ROOT
-				}
-
-				any_demesne_title = {
-					OR = {
-						is_primary_holder_title = yes
-						higher_tier_than = DUKE
-					}
-
-					ROOT = {
-						primary_title = {
-							de_jure_liege_or_above = PREVPREV
-						}
-					}
-
-					any_claimant = {
-						culture = ROOT
-						religion = ROOT
-					}
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
+			# To keep leading the faction
 			trigger_if = {
 				limit = { leads_faction = faction_independence }
-				opinion = { who = LIEGE value >= 80 }
+
+				opinion = {
+					who = liege
+					value < 80
+				}
 			}
+			# To start the faction
 			trigger_else = {
-				opinion = { who = LIEGE value >= 60 }
+				opinion = {
+					who = liege
+					value < 60
+				}
 			}
 		}
 
-		modifier = {
-			factor = 0
-			preparing_invasion = yes
+		mult_modifier = {
+			factor = 0.5
+			liege = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_less_factions
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
+			factor = 0.2
+			liege = { pacifist = yes }
+		}
+		mult_modifier = {
 			factor = 0.1
 			trigger_if = {
 				limit = { religion_group = pagan_group }
 				is_reformed_religion = yes
 			}
 			liege = {
-				distance = { who = ROOT distance < 200 }
+				distance = {
+					who = ROOT
+					value < 200
+				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			liege = {
 				religion = ROOT
 				culture = ROOT
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			liege = {
-				distance = { who = ROOT distance >= 300 }
+				distance = {
+					who = ROOT
+					value >= 300
+				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			liege = {
-				distance = { who = ROOT distance >= 400 }
+				distance = {
+					who = ROOT
+					value >= 400
+				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			religion_group = pagan_group
 			is_reformed_religion = no
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			liege = {
-				NOT = { religion_group = ROOT }
-			}
+			NOT = { religion_group = liege }
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			liege = {
-				NOT = { culture_group = ROOT }
-			}
+			NOT = { culture_group = liege }
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
-			opinion = { who = LIEGE value >= 20 }
-		}
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 40 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
+			opinion = {
+				who = liege
+				value >= 20
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -20 }
+			opinion = {
+				who = liege
+				value < -20
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
+			opinion = {
+				who = liege
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
+			opinion = {
+				who = liege
+				value < -75
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.025
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.025
 			trait = imbecile
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.025
 			trait = craven
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			OR = {
 				trait = slow
 				trait = dull
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			primary_title = {
 				is_vice_royalty = yes
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			OR = {
-				has_opinion_modifier = { who = LIEGE modifier = opinion_evil_tyrant }
-				has_opinion_modifier = { who = LIEGE modifier = opinion_tyrant }
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_evil_tyrant
+				}
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_tyrant
+				}
 			}
 		}
-		modifier = { # More likely to want to go independent from the WP if China is unstable
+		mult_modifier = { # More likely to want to go independent from the WP if China is unstable
 			factor = 10.0
 			liege = {
 				government = confucian_bureaucracy
@@ -4802,15 +4567,162 @@ faction_independence = {
 	membership = {
 		factor = 4
 
-		modifier = {
-			factor = 0.5
-			ROOT = {
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOR = {
+				has_character_modifier = faction_independence_ultimatum_timer
+				has_landed_title = k_orthodox
+
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
+				}
+
 				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+					year < 1350
+					has_horde_culture = yes
+					culture = ROOT
+					religion = ROOT
+				}
+			}
+
+			trigger_if = {
+				limit = { is_patrician = yes }
+				is_merchant_republic = no
+			}
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						is_heir = liege
+
+						# To stay in the faction
+						trigger_if = {
+							limit = { in_faction = faction_independence }
+							opinion = {
+								who = liege
+								value >= 80
+							}
+						}
+						# To join the faction
+						trigger_else = {
+							opinion = {
+								who = liege
+								value >= 60
+							}
+						}
+
+						AND = {
+							religion = liege
+							culture = liege
+
+							trigger_if = {
+								limit = {
+									religion_group = pagan_group
+									is_reformed_religion = no
+								}
+
+								distance = {
+									who = liege
+									value < 100
+								}
+							}
+							trigger_else = {
+								distance = {
+									who = liege
+									value < 200
+								}
+							}
+
+							de_jure_liege_or_above = liege
+							lower_tier_than = KING
+						}
+
+						AND = {
+							lower_tier_than = KING
+
+							trigger_if = {
+								limit = { religion_group = pagan_group }
+								is_reformed_religion = yes
+							}
+
+							culture_group = liege
+							religion_group = liege
+
+							OR = {
+								religion = liege
+								culture = liege
+							}
+
+							distance = {
+								who = liege
+								value < 200
+							}
+						}
+
+						# Try to exclude people who should rather support a claimant
+						liege = {
+							NAND = {
+								culture = ROOT
+								religion = ROOT
+							}
+
+							any_demesne_title = {
+								OR = {
+									is_primary_holder_title = yes
+									higher_tier_than = DUKE
+								}
+
+								ROOT = {
+									primary_title = {
+										de_jure_liege_or_above = PREVPREV
+									}
+								}
+
+								any_claimant = {
+									culture = ROOT
+									religion = ROOT
+								}
+							}
+						}
+
+						# Won't join this type of faction if our capital borders the liege's capital
+						liege = {
+							capital_scope = {
+								any_neighbor_province = {
+									ROOT = {
+										capital_scope = {
+											province = PREVPREV
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
 				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
+			factor = 0.5
+			liege = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_less_factions
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -4820,213 +4732,14 @@ faction_independence = {
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				has_landed_title = k_orthodox
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			is_patrician = yes
-			is_merchant_republic = no
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				religion = ROOT
-				culture = ROOT
-
-				OR = {
-					distance = { who = ROOT distance < 100 }
-
-					AND = {
-						distance = { who = ROOT distance < 200 }
-						ROOT = {
-							trigger_if = {
-								limit = { religion_group = pagan_group }
-								is_reformed_religion = yes
-							}
-						}
-					}
-
-					AND = {
-						de_jure_vassal_or_below = ROOT
-						ROOT = { lower_tier_than = KING }
-					}
-				}
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			lower_tier_than = KING
-
-			trigger_if = {
-				limit = { religion_group = pagan_group }
-				is_reformed_religion = yes
-			}
-
-			liege = {
-				culture_group = ROOT
-				religion_group = ROOT
-
-				OR = {
-					religion = ROOT
-					culture = ROOT
-				}
-
-				distance = { who = ROOT distance < 200 }
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_independence_ultimatum_timer
-		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-
-			liege = {
-				NAND = {
-					culture = ROOT
-					religion = ROOT
-				}
-
-				any_demesne_title = {
-					OR = {
-						is_primary_holder_title = yes
-						higher_tier_than = DUKE
-					}
-
-					ROOT = {
-						primary_title = {
-							de_jure_liege_or_above = PREVPREV
-						}
-					}
-
-					any_claimant = {
-						culture = ROOT
-						religion = ROOT
-					}
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			trigger_if = {
-				limit = { in_faction = faction_independence }
-				opinion = { who = LIEGE value >= 80 }
-			}
-			trigger_else = {
-				opinion = { who = LIEGE value >= 60 }
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-
-			# Won't join this type of faction if our capital borders the liege's capital
-			liege = {
-				capital_scope = {
-					any_neighbor_province = {
-						ROOT = {
-							capital_scope = {
-								province = PREVPREV
-							}
-						}
-					}
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trigger_if = {
 				limit = { religion_group = pagan_group }
@@ -5034,7 +4747,10 @@ faction_independence = {
 			}
 
 			liege = {
-				distance = { who = ROOT distance < 200 }
+				distance = {
+					who = ROOT
+					value < 200
+				}
 			}
 
 			NOT = {
@@ -5044,9 +4760,8 @@ faction_independence = {
 				}
 			}
 		}
-
 		# Clans are very unlikely to join Independence factions led by non-nomads
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			is_nomadic = yes
 			FROM = {
@@ -5059,8 +4774,7 @@ faction_independence = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			liege = {
 				religion = ROOT
@@ -5073,47 +4787,55 @@ faction_independence = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			liege = {
-				distance = { who = ROOT distance >= 300 }
+				distance = {
+					who = ROOT
+					value >= 300
+				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			liege = {
-				distance = { who = ROOT distance >= 400 }
+				distance = {
+					who = ROOT
+					value >= 400
+				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			religion_group = pagan_group
 			is_reformed_religion = no
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			liege = {
 				NOT = { religion_group = ROOT }
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			liege = {
 				NOT = { culture_group = ROOT }
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
-			opinion = { who = LIEGE value = 20 }
+			opinion = {
+				who = liege
+				value = 20
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0
-			opinion = { who = LIEGE value = 40 }
+			opinion = {
+				who = liege
+				value = 40
+			}
 			NOT = {
 				has_opinion_modifier = {
 					who = FROM
@@ -5121,20 +4843,29 @@ faction_independence = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -20 }
+			opinion = {
+				who = liege
+				value < -20
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
+			opinion = {
+				who = liege
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
+			opinion = {
+				who = liege
+				value < -75
+			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.025
 			trait = content
 			NOT = {
@@ -5144,7 +4875,7 @@ faction_independence = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.025
 			trait = imbecile
 			NOT = {
@@ -5154,7 +4885,7 @@ faction_independence = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.025
 			trait = craven
 			NOT = {
@@ -5164,7 +4895,7 @@ faction_independence = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -5174,7 +4905,7 @@ faction_independence = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			OR = {
 				trait = slow
@@ -5187,66 +4918,72 @@ faction_independence = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			OR = {
-				has_opinion_modifier = { who = LIEGE modifier = opinion_evil_tyrant }
-				has_opinion_modifier = { who = LIEGE modifier = opinion_tyrant }
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_evil_tyrant
+				}
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_tyrant
+				}
 			}
 		}
-		modifier = { # More likely to want to go independent from the WP if China is unstable
+		mult_modifier = { # More likely to want to go independent from the WP if China is unstable
 			factor = 10.0
 			liege = {
 				government = confucian_bureaucracy
@@ -5268,6 +5005,7 @@ faction_independence = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_independence
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -5291,21 +5029,14 @@ faction_claimant = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		higher_tier_than = BARON
+		independent = no
 		is_adult = yes
-
-		NOR = {
-			is_incapable = yes
-			has_character_modifier = faction_claimant_timer
-		}
-
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
-		}
+		prisoner = no
+		is_incapable = no
+		holy_order = no
+		NOT = { has_character_modifier = faction_claimant_timer }
 
 		liege = {
 			is_vice_royalty = no
@@ -5319,7 +5050,8 @@ faction_claimant = {
 			OR = {
 				# Hordes should have less problems with this type of faction until ca 1350
 				year > 1350
-				primary_title = { is_tribal = no }
+				has_horde_culture = no
+
 				NAND  = {
 					culture = ROOT
 					religion = ROOT
@@ -5336,14 +5068,19 @@ faction_claimant = {
 		trigger_if = {
 			limit = { has_dlc = "Conclave" }
 
-			is_voter = no
-			is_nomadic = yes
-			is_tribal = yes
+			OR = {
+				is_voter = no
+				is_nomadic = yes
+				is_tribal = yes
 
-			liege = {
-				OR = {
-					is_council_content = no
-					NOT = { primary_title = { has_law = war_voting_power_1 } }
+				liege = {
+					OR = {
+						is_council_content = no
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
+					}
 				}
 			}
 		}
@@ -5351,6 +5088,8 @@ faction_claimant = {
 		trigger_if = {
 			limit = {
 				# If affected by a Crown Law title
+				NOT = { has_dlc = "Conclave" }
+
 				crownlaw_title = {
 					always = yes
 				}
@@ -5379,21 +5118,19 @@ faction_claimant = {
 			}
 		}
 
-		OR = {
-			liege = {
-				is_nomadic = no
-			}
-
-			AND = {
+		trigger_if = {
+			limit = {
 				liege = {
 					is_nomadic = yes
-					NOT = { has_blood_oath_with = PREV }
 				}
-				is_nomadic = yes
-				new_character = {
-					character = PREV
-				}
-				has_dlc = "Horse Lords"
+			}
+
+			has_dlc = "Horse Lords"
+			is_nomadic = yes
+			NOT = { has_blood_oath_with = liege }
+
+			new_character = { # Claimant
+				character = PREV
 			}
 		}
 	}
@@ -5405,8 +5142,8 @@ faction_claimant = {
 			higher_tier_than = DUKE
 		}
 
-		NOT = {
-			holder_scope = {
+		holder_scope = {
+			NOT = {
 				reverse_has_opinion_modifier = {
 					who = FROM
 					modifier = opinion_coerced_into_leaving_faction
@@ -5429,38 +5166,28 @@ faction_claimant = {
 
 			trigger_if = {
 				limit = { is_female = no }
+
 				NOR = {
 					religion_group = muslim
-					ROOT = { succ_law_title = { has_law = enatic_succession } }
 					has_religion_feature = religion_matriarchal
+					ROOT = {
+						succ_law_title = {
+							has_law = enatic_succession
+						}
+					}
 				}
 			}
 			trigger_else = {
 				NOR = {
 					religion_group = muslim
-					ROOT = { succ_law_title = { has_law = agnatic_succession } }
 					has_religion_feature = religion_patriarchal
+					ROOT = {
+						succ_law_title = {
+							has_law = agnatic_succession
+						}
+					}
 				}
 			}
-
-#			OR = {
-#				OR = {
-#					is_female = no
-#					NOR = {
-#						religion_group = muslim
-#						ROOT = { succ_law_title = { has_law = agnatic_succession } }
-#						has_religion_feature = religion_patriarchal
-#					}
-#				}
-#				OR = {
-#					is_female = yes
-#					NOR = {
-#						religion_group = muslim
-#						ROOT = { succ_law_title = { has_law = enatic_succession } }
-#						has_religion_feature = religion_matriarchal
-#					}
-#				}
-#			}
 
 			OR = {
 				has_claim = ROOT
@@ -5477,17 +5204,19 @@ faction_claimant = {
 				has_landed_title = d_fraticelli
 			}
 
-			OR = {
-				is_ruler = no
-				primary_title = {
-					OR = {
-						is_primary_type_title = no # Static Mercs, the Pope, Holy Orders, etc
-						higher_tier_than = ROOT
-						tier = ROOT
+			# The Pope, static mercs and holy orders shouldn't get titles at or above their tier
+			trigger_if = {
+				limit = {
+					is_ruler = yes
+
+					primary_title = {
+						is_primary_type_title = yes
 					}
 				}
+				lower_tier_than = ROOT
 			}
 
+			# Claimant isn't already fighting for claim on this title
 			ROOT = {
 				holder_scope = {
 					NOT = {
@@ -5506,12 +5235,10 @@ faction_claimant = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
+			independent = no
 			is_adult = yes
 			prisoner = no
-
 			is_incapable = no
 
 			trigger_if = {
@@ -5525,7 +5252,10 @@ faction_claimant = {
 					liege = {
 						OR = {
 							is_council_content = no
-							NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+							primary_title = {
+								NOT = { has_law = war_voting_power_1 }
+							}
 						}
 					}
 				}
@@ -5534,10 +5264,7 @@ faction_claimant = {
 			# Can't join factions when in blood oath with liege
 			trigger_if = {
 				limit = { is_nomadic = yes }
-
-				liege = {
-					NOT = { has_blood_oath_with = PREV }
-				}
+				NOT = { has_blood_oath_with = liege }
 			}
 		}
 	}
@@ -5546,175 +5273,211 @@ faction_claimant = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			holder_scope = {
-				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
-			}
-		}
-		modifier = {
-			factor = 0.2
-			FROM = { pacifist = yes }
-		}
-
-		modifier = {
-			factor = 0
+		trigger = {
 			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
+				# If I have a claim, don't support anyone else
+				trigger_if = {
+					limit = { has_claim = ROOT }
+					new_character = { character = FROM }
 				}
-			}
-		}
 
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
+				# To keep leading the faction
+				trigger_if = {
+					limit = { leads_faction = faction_claimant }
 
-		# Will not install old women
-		modifier = {
-			factor = 0
-			new_character = {
-				is_female = yes
-				age >= 40
-			}
-		}
-
-		# Will not install a parent of the current ruler
-		modifier = {
-			factor = 0
-			new_character = {
-				FROM = {
-					liege = {
-						is_parent_of = PREVPREV
+					opinion = {
+						who = liege
+						value < 50
 					}
 				}
-			}
-		}
+				# To start the faction
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 25
+					}
+				}
 
-		# Title does NOT have Elective and I'm the current heir
-		modifier = {
-			factor = 0
-			NOR = {
-				has_law = succ_feudal_elective
-				has_law = succ_hre_elective
-			}
+				prisoner = no
+				NOT = { has_character_modifier = in_seclusion }
+				preparing_invasion = no
 
-			current_heir = {
-				OR = {
-					character = FROM
-					ROOT = {
-						new_character = {
-							character = PREVPREV
+				# Religious dogma check
+				trigger_if = {
+					limit = { has_religion_feature = religion_patriarchal }
+					new_character = { is_female = no }
+				}
+				trigger_else_if = {
+					limit = { has_religion_feature = religion_matriarchal }
+					new_character = { is_female = yes }
+				}
+
+				# If there is an antiking faction, prioritize that
+				trigger_if = {
+					limit = {
+						OR = {
+							religion = catholic
+							religion = fraticelli
+						}
+
+						top_liege = {
+							is_liege_of = FROM
+							religion = FROM
+
+							# Has an antipope
+							rightful_religious_head_scope = {
+								OR = {
+									has_claim = k_papal_state
+									has_claim = d_fraticelli
+								}
+							}
+						}
+					}
+
+					liege = {
+						NOT = {
+							faction_exists = {
+								faction = faction_antiking
+								title = ROOT
+							}
 						}
 					}
 				}
 			}
-		}
 
-		# Do not push non-dynasty claimants if liege is my dynasty
-		modifier = {
-			factor = 0
+			# Only support claimants of my culture (for both the conquered and the conquerors)
+			trigger_if = {
+				limit = { is_conquered = yes }
+				new_character = { culture = FROM }
+			}
+
 			holder_scope = {
-				dynasty = FROM
-				religion = FROM
-				culture = FROM
-			}
-			new_character = {
-				NOT = { dynasty = FROM }
-			}
-		}
+				NOT = { is_married = FROM }
 
-		modifier = {
-			factor = 0
-			new_character = {
-				ROOT = {
-					holder_scope = {
-						is_child_of = PREVPREV
+				# None of my liege's primary tier titles are my de jure liege title
+				NOT = {
+					any_demesne_title = {
+						is_primary_holder_title_tier = yes
+						de_jure_vassal_or_below = FROM
 					}
 				}
 			}
-		}
 
-		# If claimaint's sex is incompatible with religious dogma.
-		modifier = {
-			factor = 0
-			FROM = {
-				has_religion_feature = religion_patriarchal
-			}
 			new_character = {
-				is_female = yes
-			}
-		}
-		modifier = {
-			factor = 0
-			FROM = {
-				has_religion_feature = religion_matriarchal
-			}
-			new_character = {
-				is_female = no
-			}
-		}
+				religion = FROM
+				culture_group = FROM
+				is_incapable = no
 
-		# Or if vassal is under the yoke of the wrong kind of liege.
-		modifier = {
-			factor = 3
-			FROM = {
-				has_religion_feature = religion_patriarchal
-				is_female = yes
-			}
-			new_character = {
-				is_female = no
-			}
-		}
-		modifier = {
-			factor = 3
-			FROM = {
-				has_religion_feature = religion_matriarchal
-				is_female = no
-			}
-			new_character = {
-				is_female = yes
-			}
-		}
-		modifier = {
-			factor = 0
-			new_character = {
-				OR = {
-					NAND = {
-						religion = FROM
-						culture_group = FROM
-					}
+				NOR = {
 					trait = blinded
 					trait = eunuch
-					is_incapable = yes
 					trait = imbecile
 					trait = inbred
 				}
-			}
-		}
 
-		modifier = {
-			factor = 0
-			OR = {
-				has_law = succ_hre_elective
-				has_law = succ_feudal_elective
+				# Will not install old women
+				trigger_if = {
+					limit = { is_female = yes }
+					age < 40
+				}
+
+				# If I'm not the claimant, opinion of the claimant matters
+				trigger_if = {
+					limit = {
+						NOT = { character = FROM }
+					}
+
+					FROM = {
+						# To keep leading the faction
+						trigger_if = {
+							limit = { leads_faction = faction_claimant }
+
+							opinion_diff = {
+								first = PREV
+								second = liege
+								value >= -25
+								as_if_liege = yes
+							}
+						}
+						# To start the faction
+						trigger_else = {
+							opinion_diff = {
+								first = PREV
+								second = liege
+								value >= 5 # I like the Claimant more than the current ruler
+								as_if_liege = yes
+							}
+						}
+					}
+				}
+
+				# Will not install a parent or child of the current ruler
+				FROM = {
+					liege = {
+						NOR = {
+							is_child_of = PREVPREV
+							is_parent_of = PREVPREV
+						}
+					}
+				}
 			}
-			new_character = {
-				character = FROM
-				NOR = {
-					trait = ambitious
-					trait = deceitful
-					trait = proud
-					has_strong_claim = PREV
+
+			# Title does NOT have Elective and I'm the current heir
+			trigger_if = {
+				limit = {
+					NOR = {
+						has_law = succ_feudal_elective
+						has_law = succ_hre_elective
+					}
+				}
+
+				current_heir = {
+					NOT = { character = FROM }
+				}
+
+				# Vanilla original, without negation
+			#	current_heir = {
+			#		OR = {
+			#			character = FROM
+			#			ROOT = {
+			#				new_character = {
+			#					character = PREVPREV
+			#				}
+			#			}
+			#		}
+			#	}
+			}
+
+			# Under elective law, only faction for self for these reasons
+			trigger_else = {
+				new_character = {
+					character = FROM
+
+					OR = {
+						trait = ambitious
+						trait = deceitful
+						trait = proud
+						has_strong_claim = PREV
+					}
+				}
+			}
+
+			# Only push dynasty claimants if liege is my dynasty
+			trigger_if = {
+				limit = {
+					holder_scope = {
+						dynasty = FROM
+						religion = FROM
+						culture = FROM
+					}
+				}
+				new_character = {
+					dynasty = FROM
 				}
 			}
 		}
 
-		#modifier = {
+		#mult_modifier = {
 		#	factor = 0
 		#	NOT = { has_law = succ_feudal_elective }
 		#	holder_scope = {
@@ -5734,160 +5497,67 @@ faction_claimant = {
 		#	}
 		# }
 
-		modifier = {
-			factor = 0
-			FROM = {
-				trigger_if = {
-					limit = { leads_faction = faction_claimant }
-					opinion = { who = LIEGE value >= 75 }
-				}
-				trigger_else = {
-					opinion = { who = LIEGE value >= 50 }
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			NOT = { new_character = { character = FROM } }
-			FROM = {
-				has_claim = ROOT
-			}
-		}
-
-		modifier = {
-			factor = 0
-			NOT = { de_jure_vassal_or_below = FROM }
-			holder_scope = {
-				any_demesne_title = {
-					is_primary_holder_title_tier = yes
-					de_jure_vassal_or_below = FROM
-					NOT = { title = ROOT }
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			is_conquered = yes
-			NOT = { new_character = { culture = FROM } }
-		}
-
-		# If there is an antiking faction, prioritize that
-		modifier = {
-			factor = 0
-			FROM = {
-				OR = {
-					religion = catholic
-					religion = fraticelli
-				}
-				top_liege = {
-					FROM = {
-						liege = {
-							character = PREVPREV
-						}
-					}
-					religion = FROM
-					rightful_religious_head_scope = {
-						OR = {
-							has_claim = k_papal_state
-							has_claim = d_fraticelli
-						}
-					}
-					any_realm_lord = {
-						in_faction = faction_antiking
-					}
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			NOT = {
-				new_character = {
-					character = FROM
-				}
-			}
-			NOT = {
-				new_character = {
-					FROM = {
-						trigger_if = {
-							limit = { in_faction = faction_claimant }
-							opinion_diff = {
-								first = PREV
-								second = LIEGE
-								value >= -25
-								as_if_liege = yes
-							}
-						}
-						trigger_else = {
-							opinion_diff = {
-								first = PREV
-								second = LIEGE
-								value >= 5 # I like the Claimant more than the current ruler
-								as_if_liege = yes
-							}
-						}
-					}
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
+
+			# If we are subjugated, tend to unite behind one single claimant
 			is_conquered = yes
 			NOT = { conquest_culture = FROM }
+
 			holder_scope = {
-				any_vassal = {
-					NOT = { character = FROM }
-					in_faction = faction_claimant
-					faction_claimant = {
-						new_character = {
-							culture = FROM # If we are subjugated, tend to unite behind one single claimant
-							FROM = {
-								opinion_diff = {
-									first = PREV
-									second = LIEGE
-									value >= 10 # I like the Claimant more than the current ruler
-									as_if_liege = yes
-								}
-							}
-						}
+				faction_exists = {
+					faction = faction_claimant
+					title = ROOT
+				}
+			}
+
+			new_character = {
+				culture = FROM
+
+				FROM = {
+					opinion_diff = {
+						first = PREV
+						second = liege
+						value >= 10 # I like the Claimant more than the current ruler
+						as_if_liege = yes
 					}
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
+		mult_modifier = {
+			factor = 0.5
+			holder_scope = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_less_factions
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
+		mult_modifier = {
+			factor = 0.2
+			FROM = { pacifist = yes }
+		}
+		# Or if vassal is under the yoke of the wrong kind of liege.
+		mult_modifier = {
+			factor = 3
 			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
+				has_religion_feature = religion_patriarchal
+				is_female = yes
+			}
+			new_character = {
+				is_female = no
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
+			factor = 3
+			FROM = {
+				has_religion_feature = religion_matriarchal
+				is_female = no
+			}
+			new_character = {
+				is_female = yes
+			}
+		}
+		mult_modifier = {
 			factor = 0.7
 			NAND = {
 				has_dlc = "Conclave"
@@ -5910,59 +5580,73 @@ faction_claimant = {
 				is_female = yes
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			new_character = {
 				age < 13
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			new_character = {
 				age < 10
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			new_character = {
 				age < 5
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < 0 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < 0
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -25 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -25
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			new_character = {
 				character = FROM
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			new_character = {
 				dynasty = FROM
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			title = e_byzantium
 			FROM = { culture_group = byzantine }
@@ -5971,7 +5655,7 @@ faction_claimant = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			title = e_byzantium
 			FROM = { culture_group = byzantine }
@@ -5979,7 +5663,7 @@ faction_claimant = {
 				trait = born_in_the_purple
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			title = e_byzantium
 			FROM = { culture_group = byzantine }
@@ -5988,7 +5672,7 @@ faction_claimant = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			title = e_byzantium
 			FROM = { culture_group = byzantine }
@@ -5997,7 +5681,7 @@ faction_claimant = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			new_character = {
 				trait = sayyid
@@ -6006,29 +5690,25 @@ faction_claimant = {
 				NOT = { trait = sayyid }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			new_character = {
 				trait = mirza
 			}
 			holder_scope = {
-				NOT = {
-					OR = {
-						trait = sayyid
-						trait = mirza
-					}
+				NOR = {
+					trait = sayyid
+					trait = mirza
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			is_conquered = yes
 			NOT = { conquest_culture = FROM }
 			new_character = { culture = FROM }
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			holder_scope = {
 				dynasty_realm_power >= 0.25
@@ -6041,7 +5721,7 @@ faction_claimant = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			holder_scope = {
 				dynasty_realm_power >= 0.4
@@ -6054,28 +5734,27 @@ faction_claimant = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
-			OR = {
-				is_conquered = no
+			trigger_if = {
+				limit = { is_conquered = yes }
 				conquest_culture = FROM
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -6084,26 +5763,32 @@ faction_claimant = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5
 			new_character = {
 				same_society_as = FROM
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			FROM = {
 				OR = {
-					has_opinion_modifier = { who = LIEGE modifier = opinion_evil_tyrant }
-					has_opinion_modifier = { who = LIEGE modifier = opinion_tyrant }
+					has_opinion_modifier = {
+						who = liege
+						modifier = opinion_evil_tyrant
+					}
+					has_opinion_modifier = {
+						who = liege
+						modifier = opinion_tyrant
+					}
 				}
 			}
 		}
@@ -6116,18 +5801,151 @@ faction_claimant = {
 	membership = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			ROOT = {
-				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOR = {
+				has_character_modifier = faction_claimant_timer
+
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
 				}
 			}
-		}
-		modifier = {
-			factor = 0.2
-			pacifist = yes
-			NOT = {
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						opinion = {
+							who = liege
+							value >= 40
+						}
+
+						# Exclude heretics and obviously bad rulers
+						new_character = {
+							OR = {
+								NOT = { religion = ROOT }
+								# NOT = { culture_group = ROOT }
+								trait = blinded
+								trait = eunuch
+								is_incapable = yes
+								trait = imbecile
+								trait = inbred
+							}
+						}
+
+						# I'm not the claimant and I like my liege more than the claimant
+						new_character = {
+							NOT = { character = ROOT }
+
+							ROOT = {
+								# To stay in the faction
+								trigger_if = {
+									limit = { in_faction = faction_claimant }
+
+									opinion_diff = {
+										first = liege
+										second = PREV
+										value >= -25
+										as_if_liege = yes
+									}
+								}
+								# To join the faction
+								trigger_else = {
+									opinion_diff = {
+										first = liege
+										second = PREV
+										value >= 10
+										as_if_liege = yes
+									}
+								}
+							}
+						}
+
+
+						# I do not join factions if I am the heir, unless I am the claimant
+						AND = {
+							FROMFROM = {
+								current_heir = {
+									character = ROOT
+								}
+							}
+							new_character = {
+								NOT = { character = ROOT }
+							}
+						}
+
+						# If my liege is my dynasty, only push claimants of my dynasty
+						AND = {
+							liege = {
+								dynasty = ROOT
+								religion = ROOT
+								culture = ROOT
+							}
+							new_character = {
+								NOT = { dynasty = ROOT }
+							}
+						}
+
+						# If the title is not my De Jure liege, and my liege holds my De Jure title, don't push claimants
+						FROMFROM = {
+							NOT = { de_jure_vassal_or_below = ROOT }
+							holder_scope = {
+								any_demesne_title = {
+									is_primary_holder_title_tier = yes
+									de_jure_vassal_or_below = ROOT
+									NOT = { title = PREVPREV }
+								}
+							}
+						}
+
+						# If the title is conquered only push claimants of my exact culture
+						AND = {
+							FROMFROM = { is_conquered = yes }
+							new_character = {
+								NOT = { culture = ROOT }
+							}
+						}
+
+						liege = {
+							year < 1350
+							has_horde_culture = yes
+							culture = ROOT
+							religion = ROOT
+						}
+
+						# If there is an antiking faction, prioritize that
+						AND = {
+							OR = {
+								religion = catholic
+								religion = fraticelli
+							}
+							top_liege = {
+								is_liege_of = ROOT
+								religion = ROOT
+
+								# Has an antipope
+								rightful_religious_head_scope = {
+									OR = {
+										has_claim = k_papal_state
+										has_claim = d_fraticelli
+									}
+								}
+
+								faction_exists = {
+									faction = faction_antiking
+									title = FROMFROM
+								}
+							}
+						}
+					}
+				}
+
 				has_opinion_modifier = {
 					who = FROM
 					modifier = opinion_coerced_into_joining_faction
@@ -6135,86 +5953,20 @@ faction_claimant = {
 			}
 		}
 
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = { # I do not join factions if I am the heir, unless I am the claimant
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			new_character = {
-				NOT = { character = ROOT }
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = { # If my liege is my dynasty, only push claimants of my dynasty
-			factor = 0
-			liege = {
-				dynasty = ROOT
-				religion = ROOT
-				culture = ROOT
-			}
-			new_character = {
-				NOT = { dynasty = ROOT }
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = { # Exclude heretics and obviously bad rulers
-			factor = 0
-			new_character = {
-				OR = {
-					NOT = { religion = ROOT }
-					#NOT = { culture_group = ROOT }
-					trait = blinded
-					trait = eunuch
-					is_incapable = yes
-					trait = imbecile
-					trait = inbred
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		#modifier = {
+		# mult_modifier = {
 		#	factor = 0
 		#	liege = {
 		#		culture_group = ROOT
 		#		religion = ROOT
+		#
 		#		any_war = {
 		#			war_title = FROMFROM
 		#			defender = { character = THIS }
+		#
 		#			attacker = {
-		#				OR = {
-		#					NOT = { culture_group = ROOT }
-		#					NOT = { religion = ROOT }
+		#				NAND = {
+		#					culture_group = ROOT
+		#					religion = ROOT
 		#				}
 		#			}
 		#		}
@@ -6227,18 +5979,17 @@ faction_claimant = {
 		#	}
 		# }
 
-		modifier = { # If the title is not my De Jure liege, and my liege holds my De Jure title, don't push claimants
-			factor = 0
-			FROMFROM = {
-				NOT = { de_jure_vassal_or_below = ROOT }
-				holder_scope = {
-					any_demesne_title = {
-						is_primary_holder_title_tier = yes
-						de_jure_vassal_or_below = ROOT
-						NOT = { title = PREVPREV }
-					}
+		mult_modifier = {
+			factor = 0.5
+			ROOT = {
+				liege = {
+					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
 				}
 			}
+		}
+		mult_modifier = {
+			factor = 0.2
+			pacifist = yes
 			NOT = {
 				has_opinion_modifier = {
 					who = FROM
@@ -6246,23 +5997,7 @@ faction_claimant = {
 				}
 			}
 		}
-
-		modifier = { # If the title is conquered only push claimants of my exact culture
-			factor = 0
-			FROMFROM = {
-				is_conquered = yes
-			}
-			NOR = {
-				new_character = { culture = ROOT }
-
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = { # Lower chance of joining if I myself has a claim on the same title
+		mult_modifier = { # Lower chance of joining if I myself have a claim on the same title
 			factor = 0.1
 			FROMFROM = {
 				claimed_by = ROOT
@@ -6276,142 +6011,26 @@ faction_claimant = {
 				}
 			}
 		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_claimant_timer
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 40 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		# If there is an antiking faction, prioritize that
-		modifier = {
-			factor = 0
-			OR = {
-				religion = catholic
-				religion = fraticelli
-			}
-			top_liege = {
-				ROOT = {
-					liege = {
-						character = PREVPREV
-					}
-				}
-				religion = ROOT
-				rightful_religious_head_scope = {
-					OR = {
-						has_claim = k_papal_state
-						has_claim = d_fraticelli
-					}
-				}
-				any_realm_lord = {
-					in_faction = faction_antiking
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = { # If the claimant is not me, make sure I like the claimant more than my current liege
-			factor = 0
-			NOT = {
-				new_character = {
-					character = ROOT
-				}
-			}
-
-			NOT = {
-				new_character = {
-					ROOT = {
-						trigger_if = {
-							limit = { in_faction = faction_claimant }
-							opinion_diff = {
-								first = PREV
-								second = LIEGE
-								value >= -25
-								as_if_liege = yes
-							}
-						}
-						trigger_else = {
-							opinion_diff = {
-								first = PREV
-								second = LIEGE
-								value >= 10 # I like the Claimant more than the current ruler
-								as_if_liege = yes
-							}
-						}
-					}
-				}
-			}
-
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			new_character = {
 				character = ROOT
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			new_character = {
 				dynasty = ROOT
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.7
 			NAND = {
 				has_dlc = "Conclave"
@@ -6436,32 +6055,28 @@ faction_claimant = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			new_character = {
 				age < 13
 				NOT = { character = ROOT }
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			new_character = {
 				age < 10
 				NOT = { character = ROOT }
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			new_character = {
 				age < 5
 				NOT = { character = ROOT }
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			culture_group = byzantine
 			FROMFROM = {
@@ -6471,8 +6086,7 @@ faction_claimant = {
 				NOT = { trait = born_in_the_purple }
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			culture_group = byzantine
 			FROMFROM = {
@@ -6482,8 +6096,7 @@ faction_claimant = {
 				trait = born_in_the_purple
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			culture_group = byzantine
 			FROMFROM = {
@@ -6493,8 +6106,7 @@ faction_claimant = {
 				trait = born_in_the_purple
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			culture_group = byzantine
 			FROMFROM = {
@@ -6504,8 +6116,7 @@ faction_claimant = {
 				NOT = { trait = born_in_the_purple }
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			new_character = {
 				religion_group = muslim
@@ -6516,7 +6127,7 @@ faction_claimant = {
 				NOT = { trait = sayyid }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			new_character = {
 				religion_group = muslim
@@ -6530,55 +6141,51 @@ faction_claimant = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			new_character = {
 				ROOT = {
 					opinion_diff = {
 						first = PREV
-						second = LIEGE
+						second = liege
 						value >= 20
 						as_if_liege = yes
 					}
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			new_character = {
 				ROOT = {
 					opinion_diff = {
 						first = PREV
-						second = LIEGE
+						second = liege
 						value >= 30
 						as_if_liege = yes
 					}
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			new_character = {
 				ROOT = {
 					opinion_diff = {
 						first = PREV
-						second = LIEGE
+						second = liege
 						value >= 40
 						as_if_liege = yes
 					}
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			FROMFROM = {
-				OR = {
-					is_conquered = no
+				trigger_if = {
+					limit = { is_conquered = yes }
 					conquest_culture = ROOT
 				}
 			}
@@ -6589,8 +6196,7 @@ faction_claimant = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			liege = {
 				dynasty_realm_power >= 0.25
@@ -6603,8 +6209,7 @@ faction_claimant = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			liege = {
 				dynasty_realm_power >= 0.40
@@ -6617,8 +6222,7 @@ faction_claimant = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -6628,7 +6232,7 @@ faction_claimant = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -6638,7 +6242,7 @@ faction_claimant = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -6648,7 +6252,7 @@ faction_claimant = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -6661,67 +6265,83 @@ faction_claimant = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5
-			FROMFROM = {
-				new_character = {
-					same_society_as = ROOT
-				}
+			new_character = {
+				same_society_as = ROOT
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < 0 }
+			opinion = {
+				who = liege
+				value < 0
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -25 }
+			opinion = {
+				who = liege
+				value < -25
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
+			opinion = {
+				who = liege
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
+			opinion = {
+				who = liege
+				value < -75
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			OR = {
-				has_opinion_modifier = { who = LIEGE modifier = opinion_evil_tyrant }
-				has_opinion_modifier = { who = LIEGE modifier = opinion_tyrant }
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_evil_tyrant
+				}
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_tyrant
+				}
 			}
 		}
 	}
@@ -6746,35 +6366,31 @@ faction_antiking = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		higher_tier_than = COUNT
 		is_adult = yes
+		independent = no
+		prisoner = no
+		is_incapable = no
+		holy_order = no
+		NOT = { has_character_modifier = faction_antiking_ultimatum_timer }
 
 		OR = {
 			religion = catholic
 			religion = fraticelli
 		}
 
-		NOR = {
-			is_incapable = yes
-			has_character_modifier = faction_antiking_ultimatum_timer
-		}
-
-		primary_title = {
-			holy_order = no
-			higher_tier_than = COUNT
-		}
-
 		liege = {
 			religion = ROOT
+
+			# Has an antipope
 			rightful_religious_head_scope = {
 				OR = {
 					has_claim = k_papal_state
 					has_claim = d_fraticelli
 				}
 			}
+
 			NOT = {
 				any_demesne_title = {
 					temporary = yes
@@ -6793,7 +6409,10 @@ faction_antiking = {
 				liege = {
 					OR = {
 						is_council_content = no
-						NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
 					}
 				}
 			}
@@ -6807,6 +6426,7 @@ faction_antiking = {
 
 		holder_scope = {
 			independent = yes
+
 			NOR = {
 				any_war = {
 					war_title = ROOT
@@ -6822,6 +6442,7 @@ faction_antiking = {
 
 		OR = {
 			culture = FROM
+
 			holder_scope = {
 				culture = FROM
 			}
@@ -6840,12 +6461,10 @@ faction_antiking = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
 			is_adult = yes
+			independent = no
 			prisoner = no
-
 			is_incapable = no
 
 			trigger_if = {
@@ -6855,10 +6474,14 @@ faction_antiking = {
 					is_voter = no
 					is_nomadic = yes
 					is_tribal = yes
+
 					liege = {
 						OR = {
 							is_council_content = no
-							NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+							primary_title = {
+								NOT = { has_law = war_voting_power_1 }
+							}
 						}
 					}
 				}
@@ -6870,100 +6493,102 @@ faction_antiking = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
+		trigger = {
+			FROM = {
+				prisoner = no
+				NOT = { has_character_modifier = in_seclusion }
+
+				trigger_if = {
+					limit = {
+						OR = {
+							trait = envious
+							trait = deceitful
+							trait = ambitious
+						}
+					}
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 25
+					}
+				}
+			}
+
 			holder_scope = {
-				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+				NOT = { is_married = FROM }
+			}
+
+			current_heir = {
+				NOT = { character = FROM }
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
+			factor = 0.5
+			holder_scope = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_less_factions
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 0.2
 			FROM = { pacifist = yes }
 		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		modifier = {
-			factor = 0
-			current_heir = {
-				character = FROM
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -10 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -10
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			NOT = { claimed_by = FROM }
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -6972,55 +6597,55 @@ faction_antiking = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -7033,85 +6658,73 @@ faction_antiking = {
 	membership = {
 		factor = 1
 
-		modifier = {
+		trigger = {
+			is_adult = yes
+			is_landed = yes
+			religion = FROM
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOR = {
+				has_character_modifier = faction_antiking_ultimatum_timer
+
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
+				}
+			}
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						# I don't like the faction leader
+						opinion = {
+							who = FROM
+							value < -40
+						}
+
+						# I like my liege
+						opinion = {
+							who = liege
+							value >= 25
+						}
+
+						# I'm the current heir
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+					}
+				}
+
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
+				}
+			}
+		}
+
+		mult_modifier = {
 			factor = 0.5
 			ROOT = {
 				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
+					}
 				}
 			}
 		}
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-				NOT = { religion = FROM }
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_antiking_ultimatum_timer
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = FROM value < -40 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 25 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -7121,21 +6734,28 @@ faction_antiking = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -10 }
+			opinion = {
+				who = liege
+				value < -10
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
+			opinion = {
+				who = liege
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
+			opinion = {
+				who = liege
+				value < -75
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -7145,7 +6765,7 @@ faction_antiking = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -7155,7 +6775,7 @@ faction_antiking = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -7165,7 +6785,7 @@ faction_antiking = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -7175,7 +6795,7 @@ faction_antiking = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -7188,55 +6808,55 @@ faction_antiking = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -7261,20 +6881,14 @@ faction_overthrow = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
+		is_nomadic = yes
 		is_landed = yes
 		is_adult = yes
-		is_nomadic = yes
-
+		independent = no
+		prisoner = no
 		is_incapable = no
-
-		liege = {
-			NOT = { has_blood_oath_with = PREV }
-		}
-
-		primary_title = { holy_order = no }
+		holy_order = no
+		NOT = { has_blood_oath_with = liege }
 
 		trigger_if = {
 			limit = { has_dlc = "Conclave" }
@@ -7287,7 +6901,10 @@ faction_overthrow = {
 				liege = {
 					OR = {
 						is_council_content = no
-						NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
 					}
 				}
 			}
@@ -7326,25 +6943,28 @@ faction_overthrow = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
-			is_adult = yes
 			is_nomadic = yes
+			is_adult = yes
+			independent = no
 			prisoner = no
-
 			is_incapable = no
 
 			trigger_if = {
 				limit = { has_dlc = "Conclave" }
+
 				OR = {
 					is_voter = no
 					is_nomadic = yes
 					is_tribal = yes
+
 					liege = {
 						OR = {
 							is_council_content = no
-							NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+							primary_title = {
+								NOT = { has_law = war_voting_power_1 }
+							}
 						}
 					}
 				}
@@ -7354,9 +6974,7 @@ faction_overthrow = {
 			trigger_if = {
 				limit = { is_nomadic = yes }
 
-				liege = {
-					NOT = { has_blood_oath_with = PREV }
-				}
+				NOT = { has_blood_oath_with = liege }
 			}
 		}
 	}
@@ -7365,173 +6983,208 @@ faction_overthrow = {
 	chance = {
 		factor = 1
 
-		modifier = {
+		trigger = {
+			FROM = {
+				prisoner = no
+				NOT = { has_character_modifier = in_seclusion }
+
+				trigger_if = {
+					limit = {
+						liege = {
+							OR = {
+								is_weak_trigger = yes
+								health < 4
+							}
+						}
+					}
+
+					trigger_if = {
+						limit = {
+							OR = {
+								trait = deceitful
+								trait = ambitious
+								trait = envious
+							}
+						}
+
+						opinion = {
+							who = liege
+							value < 75
+						}
+					}
+					trigger_else = {
+						opinion = {
+							who = liege
+							value < 50
+						}
+					}
+				}
+			}
+
+			holder_scope = {
+				NOT = { is_married = FROM }
+			}
+
+			current_heir = {
+				NOT = { character = FROM }
+			}
+		}
+
+		mult_modifier = {
 			factor = 0.5
 			holder_scope = {
 				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { pacifist = yes }
 		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		modifier = {
-			factor = 0
-			current_heir = {
-				character = FROM
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-				liege = {
-					is_weak_trigger = no
-					health >= 4
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 75 }
-				OR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
-				}
-				liege = {
-					is_weak_trigger = no
-					health >= 4
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			holder_scope = {
 				clan_title = {
 					FROM = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value < -10 }
+							clan_opinion = {
+								who = PREVPREV
+								value < -10
+							}
 						}
 					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			holder_scope = {
 				clan_title = {
 					FROM = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value < -50 }
+							clan_opinion = {
+								who = PREVPREV
+								value < -50
+							}
 						}
 					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			holder_scope = {
 				clan_title = {
 					FROM = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value < -75 }
+							clan_opinion = {
+								who = PREVPREV
+								value < -75
+							}
 						}
 					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			holder_scope = {
 				clan_title = {
 					FROM = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value >= 10 }
+							clan_opinion = {
+								who = PREVPREV
+								value >= 10
+							}
 						}
 					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.05
 			holder_scope = {
 				clan_title = {
 					FROM = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value >= 50 }
+							clan_opinion = {
+								who = PREVPREV
+								value >= 50
+							}
 						}
 					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			holder_scope = {
 				clan_title = {
 					FROM = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value >= 75 }
+							clan_opinion = {
+								who = PREVPREV
+								value >= 75
+							}
 						}
 					}
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -10 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -10
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
-			FROM = { opinion = { who = LIEGE value >= 10 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value >= 10
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.05
-			FROM = { opinion = { who = LIEGE value >= 50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value >= 50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
-			FROM = { opinion = { who = LIEGE value >= 75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value >= 75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7539,8 +7192,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7548,8 +7200,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7557,8 +7208,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7569,8 +7219,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7578,8 +7227,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7587,8 +7235,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			FROM = {
 				liege = {
@@ -7596,8 +7243,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 3
 			FROM = {
 				liege = {
@@ -7605,8 +7251,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = {
 				liege = {
@@ -7617,8 +7262,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7626,8 +7270,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			FROM = {
 				liege = {
@@ -7635,24 +7278,23 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -7661,55 +7303,55 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -7722,75 +7364,74 @@ faction_overthrow = {
 	membership = {
 		factor = 1
 
-		modifier = {
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOT = {
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
+				}
+			}
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						# I am the current heir
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+
+						# I don't like the faction leader
+						opinion = {
+							who = FROM
+							value < -40
+						}
+
+						# My weak is liege, but I do like him
+						trigger_if = {
+							limit = {
+								liege = {
+									OR = {
+										is_weak_trigger = yes
+										health < 4
+									}
+								}
+							}
+
+							opinion = {
+								who = liege
+								value >= 50
+							}
+						}
+					}
+				}
+
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
+				}
+			}
+		}
+
+		mult_modifier = {
 			factor = 0.5
 			ROOT = {
 				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
+					}
 				}
 			}
 		}
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = FROM value < -40 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 50 }
-			liege = {
-				is_weak_trigger = no
-				health >= 4
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -7800,8 +7441,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7809,8 +7449,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7818,8 +7457,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7827,8 +7465,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7839,8 +7476,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7848,8 +7484,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7857,8 +7492,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			FROM = {
 				liege = {
@@ -7866,8 +7500,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 3
 			FROM = {
 				liege = {
@@ -7875,8 +7508,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = {
 				liege = {
@@ -7893,8 +7525,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = {
 				liege = {
@@ -7902,8 +7533,7 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			FROM = {
 				liege = {
@@ -7911,14 +7541,16 @@ faction_overthrow = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			liege = {
 				clan_title = {
 					ROOT = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value < -10 }
+							clan_opinion = {
+								who = PREVPREV
+								value < -10
+							}
 						}
 					}
 				}
@@ -7930,32 +7562,41 @@ faction_overthrow = {
 				clan_title = {
 					ROOT = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value < -50 }
+							clan_opinion = {
+								who = PREVPREV
+								value < -50
+							}
 						}
 					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			liege = {
 				clan_title = {
 					ROOT = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value < -75 }
+							clan_opinion = {
+								who = PREVPREV
+								value < -75
+							}
 						}
 					}
 				}
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			liege = {
 				clan_title = {
 					ROOT = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value >= 10 }
+							clan_opinion = {
+								who = PREVPREV
+								value >= 10
+							}
 						}
 					}
 				}
@@ -7967,13 +7608,16 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			liege = {
 				clan_title = {
 					ROOT = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value >= 50 }
+							clan_opinion = {
+								who = PREVPREV
+								value >= 50
+							}
 						}
 					}
 				}
@@ -7985,13 +7629,16 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.05
 			liege = {
 				clan_title = {
 					ROOT = {
 						clan_title = {
-							clan_opinion = { who = PREVPREV value >= 75 }
+							clan_opinion = {
+								who = PREVPREV
+								value >= 75
+							}
 						}
 					}
 				}
@@ -8004,7 +7651,7 @@ faction_overthrow = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
@@ -8012,21 +7659,33 @@ faction_overthrow = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -10 }
+			opinion = {
+				who = liege
+				value < -10
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
+			opinion = {
+				who = liege
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
+			opinion = {
+				who = liege
+				value < -75
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
-			opinion = { who = LIEGE value >= 10 }
+			opinion = {
+				who = liege
+				value >= 10
+			}
 			NOT = {
 				has_opinion_modifier = {
 					who = FROM
@@ -8034,9 +7693,12 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.05
-			opinion = { who = LIEGE value >= 50 }
+			opinion = {
+				who = liege
+				value >= 50
+			}
 			NOT = {
 				has_opinion_modifier = {
 					who = FROM
@@ -8044,9 +7706,12 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
-			opinion = { who = LIEGE value >= 75 }
+			opinion = {
+				who = liege
+				value >= 75
+			}
 			NOT = {
 				has_opinion_modifier = {
 					who = FROM
@@ -8055,7 +7720,7 @@ faction_overthrow = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -8065,7 +7730,7 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -8075,7 +7740,7 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -8085,7 +7750,7 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -8095,7 +7760,7 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -8108,55 +7773,55 @@ faction_overthrow = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -8180,33 +7845,28 @@ faction_increase_council_power = {
 	# Plotter scope
 	potential = {
 		has_dlc = "Conclave"
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		higher_tier_than = BARON
 		is_adult = yes
-
-		NOR = {
-			is_incapable = yes
-			has_character_modifier = faction_council_power_ultimatum_timer
-		}
-
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
-		}
+		independent = no
+		prisoner = no
+		is_incapable = no
+		holy_order = no
+		NOT = { has_character_modifier = faction_council_power_ultimatum_timer }
 
 		liege = {
 			is_nomadic = no
 
 			OR = {
 				year >= 1350
-				primary_title = { is_tribal_type_title = no }
+				has_horde_culture = no
+
 				NAND = {
 					culture = ROOT
 					religion = ROOT
 				}
 			}
+
 			NOT = {
 				any_demesne_title = {
 					temporary = yes
@@ -8221,7 +7881,10 @@ faction_increase_council_power = {
 			liege = {
 				OR = {
 					is_council_content = no
-					NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+					primary_title = {
+						NOT = { has_law = war_voting_power_1 }
+					}
 				}
 			}
 		}
@@ -8231,21 +7894,13 @@ faction_increase_council_power = {
 	allow = {
 		higher_tier_than = COUNT
 		is_primary_holder_title = yes
-		holder_scope = {
-			primary_title = {
-				ROOT = {
-					tier = PREV
-				}
-			}
+		is_primary_holder_title_tier = yes
 
+		holder_scope = {
 			NOT = {
-				any_vassal = {
-					higher_tier_than = BARON
-					NOT = {	character = FROM }
-					num_of_faction_backers = {
-						faction = faction_increase_council_power
-						value >= 0
-					}
+				faction_exists = {
+					faction = faction_increase_council_power
+					title = ROOT
 				}
 			}
 		}
@@ -8262,7 +7917,8 @@ faction_increase_council_power = {
 					has_law = war_voting_power_0
 				}
 			}
-			NOT = {
+
+			NOR = {
 				any_war = {
 					war_title = ROOT
 					using_cb = increase_council_power_war
@@ -8281,16 +7937,13 @@ faction_increase_council_power = {
 	# FROM is target
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
 			is_adult = yes
+			independent = no
 			prisoner = no
+			is_incapable = no
 
-			NOR = {
-				is_incapable = yes
-				has_character_modifier = faction_council_power_ultimatum_timer
-			}
+			NOT = { has_character_modifier = faction_council_power_ultimatum_timer }
 
 			OR = {
 				is_voter = no
@@ -8299,7 +7952,10 @@ faction_increase_council_power = {
 				liege = {
 					OR = {
 						is_council_content = no
-						NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
 					}
 				}
 			}
@@ -8310,178 +7966,187 @@ faction_increase_council_power = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			holder_scope = {
-				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
-			}
-		}
-		modifier = {
-			factor = 0.2
-			FROM = { pacifist = yes }
-		}
-
-		modifier = {
-			factor = 0
+		trigger = {
 			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
-				}
-			}
-		}
+				prisoner = no
+				NOT = { has_character_modifier = in_seclusion }
+				preparing_invasion = no
 
-		modifier = {
-			factor = 0
-			holder_scope = {
-				any_spouse = { character = FROM }
-			}
-		}
-
-		modifier = {
-			factor = 0
-			current_heir = {
-				character = FROM
-			}
-		}
-
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
-			holder_scope = {
-				NAND = {
-					culture = FROM
-					religion = FROM
-				}
-
-				any_demesne_title = {
-					OR = {
-						is_primary_holder_title = yes
-						higher_tier_than = DUKE
-					}
-
-					FROM = {
-						primary_title = {
-							de_jure_liege_or_above = PREVPREV
+				trigger_if = {
+					limit = {
+						OR = {
+							is_voter = yes
+							trait = deceitful
+							trait = ambitious
+							trait = envious
 						}
 					}
 
-					any_claimant = {
-						culture = FROM
-						religion = FROM
+					opinion = {
+						who = liege
+						value < 25
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < 50
+					}
+				}
+			}
+
+			holder_scope = {
+				NOT = { is_married = FROM }
+			}
+
+			current_heir = {
+				NOT = { character = FROM }
+			}
+
+			# Try to exclude people who should rather support a claimant
+			holder_scope = {
+				trigger_if = {
+					limit = {
+						NAND = {
+							culture = FROM
+							religion = FROM
+						}
+					}
+
+					NOT = {
+						any_demesne_title = {
+							OR = {
+								is_primary_holder_title = yes
+								higher_tier_than = DUKE
+							}
+
+							FROM = {
+								primary_title = {
+									de_jure_liege_or_above = PREVPREV
+								}
+							}
+
+							any_claimant = {
+								culture = FROM
+								religion = FROM
+							}
+						}
 					}
 				}
 			}
 		}
 
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
+		mult_modifier = {
+			factor = 0.5
+			holder_scope = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_less_factions
 				}
-				is_voter = no
 			}
 		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-			}
+		mult_modifier = {
+			factor = 0.2
+			FROM = { pacifist = yes }
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_voter = yes }
+
 			calc_true_if = {
-				amount >= 6
-				NOT = { has_law = law_voting_power_1 }
-				NOT = { has_law = banish_voting_power_1 }
-				NOT = { has_law = execution_voting_power_1 }
-				NOT = { has_law = revoke_title_voting_power_1 }
-				NOT = { has_law = grant_title_voting_power_1 }
-				NOT = { has_law = imprison_voting_power_1 }
-				NOT = { has_law = war_voting_power_1 }
+				amount < 2
+
+				has_law = law_voting_power_1
+				has_law = banish_voting_power_1
+				has_law = execution_voting_power_1
+				has_law = revoke_title_voting_power_1
+				has_law = grant_title_voting_power_1
+				has_law = imprison_voting_power_1
+				has_law = war_voting_power_1
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_voter = yes }
+
 			calc_true_if = {
-				amount >= 4
-				NOT = { has_law = law_voting_power_1 }
-				NOT = { has_law = banish_voting_power_1 }
-				NOT = { has_law = execution_voting_power_1 }
-				NOT = { has_law = revoke_title_voting_power_1 }
-				NOT = { has_law = grant_title_voting_power_1 }
-				NOT = { has_law = imprison_voting_power_1 }
-				NOT = { has_law = war_voting_power_1 }
+				amount < 4
+
+				has_law = law_voting_power_1
+				has_law = banish_voting_power_1
+				has_law = execution_voting_power_1
+				has_law = revoke_title_voting_power_1
+				has_law = grant_title_voting_power_1
+				has_law = imprison_voting_power_1
+				has_law = war_voting_power_1
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_voter = yes }
+
 			calc_true_if = {
-				amount >= 2
-				NOT = { has_law = law_voting_power_1 }
-				NOT = { has_law = banish_voting_power_1 }
-				NOT = { has_law = execution_voting_power_1 }
-				NOT = { has_law = revoke_title_voting_power_1 }
-				NOT = { has_law = grant_title_voting_power_1 }
-				NOT = { has_law = imprison_voting_power_1 }
-				NOT = { has_law = war_voting_power_1 }
+				amount < 6
+
+				has_law = law_voting_power_1
+				has_law = banish_voting_power_1
+				has_law = execution_voting_power_1
+				has_law = revoke_title_voting_power_1
+				has_law = grant_title_voting_power_1
+				has_law = imprison_voting_power_1
+				has_law = war_voting_power_1
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 10
 			FROM = {
 				is_voter = yes
 				has_position = malcontent
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -10 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -10
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -8490,55 +8155,55 @@ faction_increase_council_power = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -8551,97 +8216,89 @@ faction_increase_council_power = {
 	membership = {
 		factor = 1
 
-		modifier = {
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			NOR = {
+				has_character_modifier = faction_council_power_ultimatum_timer
+
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
+				}
+			}
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+
+						# I don't like the faction leader
+						opinion = {
+							who = FROM
+							value < -40
+						}
+
+						# I am the current heir
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+
+						liege = {
+							year < 1350
+							has_horde_culture = yes
+							culture = ROOT
+							religion = ROOT
+						}
+
+						trigger_if = {
+							limit = {
+								OR = {
+									is_voter = yes
+									trait = deceitful
+									trait = ambitious
+									trait = envious
+								}
+							}
+
+							opinion = {
+								who = liege
+								value >= 25
+							}
+						}
+						trigger_else = {
+							opinion = {
+								who = liege
+								value >= 50
+							}
+						}
+					}
+				}
+
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
+				}
+			}
+		}
+
+		mult_modifier = {
 			factor = 0.5
 			ROOT = {
 				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
+					}
 				}
 			}
 		}
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
-				}
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_council_power_ultimatum_timer
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = FROM value < -40 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 25 }
-			NOR = {
-				trait = deceitful
-				trait = ambitious
-				trait = envious
-			}
-			is_voter = no
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= 50 }
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			FROMFROM = {
 				OR = {
@@ -8650,13 +8307,13 @@ faction_increase_council_power = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.8
 			is_voter = no
 			FROMFROM = {
 				calc_true_if = {
 					amount >= 2
+
 					has_law = law_voting_power_1
 					has_law = banish_voting_power_1
 					has_law = execution_voting_power_1
@@ -8667,13 +8324,13 @@ faction_increase_council_power = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			is_voter = no
 			FROMFROM = {
 				calc_true_if = {
 					amount >= 4
+
 					has_law = law_voting_power_1
 					has_law = banish_voting_power_1
 					has_law = execution_voting_power_1
@@ -8684,13 +8341,13 @@ faction_increase_council_power = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.3
 			is_voter = no
 			FROMFROM = {
 				calc_true_if = {
 					amount >= 6
+
 					has_law = law_voting_power_1
 					has_law = banish_voting_power_1
 					has_law = execution_voting_power_1
@@ -8701,86 +8358,91 @@ faction_increase_council_power = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			is_voter = yes
 			FROMFROM = {
 				calc_true_if = {
-					amount >= 6
-					NOT = { has_law = law_voting_power_1 }
-					NOT = { has_law = banish_voting_power_1 }
-					NOT = { has_law = execution_voting_power_1 }
-					NOT = { has_law = revoke_title_voting_power_1 }
-					NOT = { has_law = grant_title_voting_power_1 }
-					NOT = { has_law = imprison_voting_power_1 }
-					NOT = { has_law = war_voting_power_1 }
+					amount < 2
+
+					has_law = law_voting_power_1
+					has_law = banish_voting_power_1
+					has_law = execution_voting_power_1
+					has_law = revoke_title_voting_power_1
+					has_law = grant_title_voting_power_1
+					has_law = imprison_voting_power_1
+					has_law = war_voting_power_1
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			is_voter = yes
 			FROMFROM = {
 				calc_true_if = {
-					amount >= 4
-					NOT = { has_law = law_voting_power_1 }
-					NOT = { has_law = banish_voting_power_1 }
-					NOT = { has_law = execution_voting_power_1 }
-					NOT = { has_law = revoke_title_voting_power_1 }
-					NOT = { has_law = grant_title_voting_power_1 }
-					NOT = { has_law = imprison_voting_power_1 }
-					NOT = { has_law = war_voting_power_1 }
+					amount < 4
+
+					has_law = law_voting_power_1
+					has_law = banish_voting_power_1
+					has_law = execution_voting_power_1
+					has_law = revoke_title_voting_power_1
+					has_law = grant_title_voting_power_1
+					has_law = imprison_voting_power_1
+					has_law = war_voting_power_1
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			is_voter = yes
 			FROMFROM = {
 				calc_true_if = {
-					amount >= 2
-					NOT = { has_law = law_voting_power_1 }
-					NOT = { has_law = banish_voting_power_1 }
-					NOT = { has_law = execution_voting_power_1 }
-					NOT = { has_law = revoke_title_voting_power_1 }
-					NOT = { has_law = grant_title_voting_power_1 }
-					NOT = { has_law = imprison_voting_power_1 }
-					NOT = { has_law = war_voting_power_1 }
+					amount < 6
+
+					has_law = law_voting_power_1
+					has_law = banish_voting_power_1
+					has_law = execution_voting_power_1
+					has_law = revoke_title_voting_power_1
+					has_law = grant_title_voting_power_1
+					has_law = imprison_voting_power_1
+					has_law = war_voting_power_1
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 10
 			is_voter = yes
 			has_position = malcontent
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -10 }
+			opinion = {
+				who = liege
+				value < -10
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
+			opinion = {
+				who = liege
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
+			opinion = {
+				who = liege
+				value < -75
+			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -8790,7 +8452,7 @@ faction_increase_council_power = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -8800,7 +8462,7 @@ faction_increase_council_power = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -8810,7 +8472,7 @@ faction_increase_council_power = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -8820,7 +8482,7 @@ faction_increase_council_power = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -8833,55 +8495,55 @@ faction_increase_council_power = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -8890,7 +8552,10 @@ faction_increase_council_power = {
 	success = {
 		holder_scope = {
 			FROM = {
-				has_opinion_modifier = { who = PREV modifier = opinion_increased_council_power }
+				has_opinion_modifier = {
+					who = PREV
+					modifier = opinion_increased_council_power
+				}
 			}
 		}
 	}
@@ -8899,6 +8564,7 @@ faction_increase_council_power = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_increase_council_power
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -8922,17 +8588,15 @@ faction_powerful_vassal_takeover = {
 	# Plotter scope
 	potential = {
 		has_dlc = "Conclave"
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
-		is_adult = yes
+		higher_tier_than = BARON
 		is_feudal = yes
-
-		NOR = {
-			is_incapable = yes
-			has_character_modifier = faction_powerful_vassal_takeover_ultimatum_timer
-		}
+		is_adult = yes
+		independent = no
+		prisoner = no
+		is_incapable = no
+		holy_order = no
+		NOT = { has_character_modifier = faction_powerful_vassal_takeover_ultimatum_timer }
 
 		OR = {
 			is_voter = no
@@ -8940,21 +8604,21 @@ faction_powerful_vassal_takeover = {
 			liege = {
 				OR = {
 					is_council_content = no
-					NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+					primary_title = {
+						NOT = { has_law = war_voting_power_1 }
+					}
 				}
 			}
 		}
 
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
-		}
-
 		liege = {
 			is_feudal = yes
+			controls_religion = no
+
 			NOR = {
 				government = chinese_imperial_government
-				controls_religion = yes
+
 				any_demesne_title = {
 					temporary = yes
 				}
@@ -8966,22 +8630,14 @@ faction_powerful_vassal_takeover = {
 	allow = {
 		higher_tier_than = DUKE
 		is_primary_holder_title = yes
+		is_primary_holder_title_tier = yes
 
 		holder_scope = {
-			primary_title = {
-				ROOT = {
-					tier = PREV
-				}
-			}
 
 			NOR = {
-				any_vassal = {
-					higher_tier_than = COUNT
-					NOT = {	character = FROM }
-					num_of_faction_backers = {
-						faction = faction_powerful_vassal_takeover
-						value >= 0
-					}
+				faction_exists = {
+					faction = faction_powerful_vassal_takeover
+					title = ROOT
 				}
 
 				any_war = {
@@ -9005,16 +8661,12 @@ faction_powerful_vassal_takeover = {
 	# Faction member scope (ROOT = joiner, FROM = target)
 	allow_join = {
 		ROOT = {
-			is_ruler = yes
-			independent = no
 			is_landed = yes
+			independent = no
 			is_adult = yes
 			prisoner = no
-
-			NOR = {
-				is_incapable = yes
-				has_character_modifier = faction_powerful_vassal_takeover_ultimatum_timer
-			}
+			is_incapable = no
+			NOT = { has_character_modifier = faction_powerful_vassal_takeover_ultimatum_timer }
 
 			OR = {
 				is_voter = no
@@ -9022,7 +8674,10 @@ faction_powerful_vassal_takeover = {
 				liege = {
 					OR = {
 						is_council_content = no
-						NOT = { primary_title = { has_law = war_voting_power_1 } }
+
+						primary_title = {
+							NOT = { has_law = war_voting_power_1 }
+						}
 					}
 				}
 			}
@@ -9033,143 +8688,151 @@ faction_powerful_vassal_takeover = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			holder_scope = {
-				any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
-			}
-		}
-		modifier = {
-			factor = 0.2
-			FROM = { pacifist = yes }
-		}
-
-		modifier = {
-			factor = 0
+		trigger = {
 			FROM = {
-				OR = {
+				prisoner = no
+				preparing_invasion = no
+
+				NOR = {
+					has_character_modifier = in_seclusion
 					leads_faction = faction_claimant
 					in_faction = faction_claimant
 				}
-			}
-		}
 
-		modifier = {
-			factor = 0
-			FROM = {
-				OR = {
-					prisoner = yes
-					has_character_modifier = in_seclusion
+				trigger_if = {
+					limit = {
+						OR = {
+							is_voter = yes
+							trait = deceitful
+							trait = ambitious
+							trait = envious
+						}
+					}
+
+					opinion = {
+						who = liege
+						value < 0
+					}
+				}
+				trigger_else = {
+					opinion = {
+						who = liege
+						value < -15
+					}
 				}
 			}
-		}
 
-		modifier = {
-			factor = 0
 			holder_scope = {
-				any_spouse = { character = FROM }
+				NOT = { is_married = FROM }
 			}
-		}
 
-		modifier = {
-			factor = 0
 			current_heir = {
-				character = FROM
+				NOT = { character = FROM }
 			}
-		}
 
-		# Try to exclude people who should rather support a claimant
-		modifier = {
-			factor = 0
+			# Try to exclude people who should rather support a claimant
 			holder_scope = {
-				any_demesne_title = {
-					OR = {
-						is_primary_holder_title = yes
-						higher_tier_than = DUKE
-					}
-
-					FROM = {
-						primary_title = {
-							de_jure_liege_or_above = PREVPREV
+				NOT = {
+					any_demesne_title = {
+						OR = {
+							is_primary_holder_title = yes
+							higher_tier_than = DUKE
 						}
-					}
 
-					any_claimant = {
-						religion = FROM
-						opinion_diff = {
-							first = FROM
-							second = LIEGE
-							value >= 10 # I like the Claimant more than the current ruler
-							as_if_liege = yes
+						FROM = {
+							primary_title = {
+								de_jure_liege_or_above = PREVPREV
+							}
+						}
+
+						any_claimant = {
+							religion = FROM
+
+							FROM = {
+								opinion_diff = {
+									first = PREV
+									second = liege
+									value >= 10 # I like the Claimant more than the current ruler
+									as_if_liege = yes
+								}
+							}
 						}
 					}
 				}
 			}
 		}
 
-		modifier = {
-			factor = 0
-			FROM = { preparing_invasion = yes }
-		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 0 }
-				NOR = {
-					trait = deceitful
-					trait = ambitious
-					trait = envious
+		mult_modifier = {
+			factor = 0.5
+			holder_scope = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_less_factions
 				}
-				is_voter = no
 			}
 		}
-
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= -15 }
-			}
+		mult_modifier = {
+			factor = 0.2
+			FROM = { pacifist = yes }
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -25 } }
-		}
-		modifier = {
-			factor = 2.0
-			FROM = { opinion = { who = LIEGE value < -50 } }
-		}
-		modifier = {
-			factor = 4.0
-			FROM = { opinion = { who = LIEGE value < -75 } }
-		}
-		modifier = {
-			factor = 0
 			FROM = {
-				NOR = {
-					has_opinion_modifier = { who = LIEGE modifier = opinion_evil_tyrant }
-					has_opinion_modifier = { who = LIEGE modifier = opinion_tyrant }
+				opinion = {
+					who = liege
+					value < -25
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
+			factor = 2.0
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
+		}
+		mult_modifier = {
+			factor = 4.0
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
+		}
+		mult_modifier = {
+			factor = 0
+			FROM = {
+				NOR = {
+					has_opinion_modifier = {
+						who = liege
+						modifier = opinion_evil_tyrant
+					}
+					has_opinion_modifier = {
+						who = liege
+						modifier = opinion_tyrant
+					}
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = imbecile }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = inbred }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			FROM = { trait = craven }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -9178,55 +8841,55 @@ faction_powerful_vassal_takeover = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = charitable }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = humble }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			FROM = { trait = just }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = proud }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = brave }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = greedy }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = impaler }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -9239,41 +8902,81 @@ faction_powerful_vassal_takeover = {
 	membership = {
 		factor = 1
 
-		modifier = {
-			factor = 0.5
-			ROOT = {
-				liege = {
-					any_owned_bloodline = { has_bloodline_flag = bloodline_less_factions }
+		trigger = {
+			is_landed = yes
+			is_adult = yes
+			prisoner = no
+			is_incapable = no
+			preparing_invasion = no
+
+			opinion = {
+				who = FROMFROM
+				value < 0
+			}
+
+			OR = {
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_evil_tyrant
+				}
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_tyrant
 				}
 			}
-		}
-		modifier = {
-			factor = 0
-			OR = {
+
+			NOR = {
 				leads_faction = faction_claimant
 				in_faction = faction_claimant
-			}
-		}
+				has_character_modifier = faction_powerful_vassal_takeover_ultimatum_timer
 
-		modifier = {
-			factor = 0
-			OR = {
-				prisoner = yes
-				is_incapable = yes
-				is_adult = no
-				is_landed = no
-				preparing_invasion = yes
-			}
-		}
-
-		modifier = {
-			factor = 0
-			FROMFROM = {
-				current_heir = {
-					character = ROOT
+				has_opinion_modifier = {
+					who = liege
+					modifier = opinion_coerced_into_leaving_faction
 				}
 			}
-			NOT = {
+
+			# The following require spymaster coercion to overrule
+			trigger_if = {
+				limit = {
+					OR = {
+						# I'm the current heir
+						FROMFROM = {
+							current_heir = {
+								character = ROOT
+							}
+						}
+
+						# I don't like the faction leader
+						opinion = {
+							who = FROM
+							value < -40
+						}
+
+						liege = {
+							year < 1350
+							has_horde_culture = yes
+							culture = ROOT
+							religion = ROOT
+						}
+
+						trigger_if = {
+							limit = { is_voter = yes }
+
+							opinion = {
+								who = liege
+								value >= -20
+							}
+						}
+						trigger_else = {
+							opinion = {
+								who = liege
+								value >= -40
+							}
+						}
+					}
+				}
+
 				has_opinion_modifier = {
 					who = FROM
 					modifier = opinion_coerced_into_joining_faction
@@ -9281,76 +8984,7 @@ faction_powerful_vassal_takeover = {
 			}
 		}
 
-		modifier = {
-			factor = 0
-			has_character_modifier = faction_powerful_vassal_takeover_ultimatum_timer
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = FROMFROM value >= 0 }
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = FROM value < -40 }
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			liege = {
-				year < 1350
-				primary_title = { is_tribal_type_title = yes }
-				culture = ROOT
-				religion = ROOT
-			}
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			has_opinion_modifier = {
-				who = LIEGE
-				modifier = opinion_coerced_into_leaving_faction
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= -40 }
-			is_voter = no
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
-			factor = 0
-			opinion = { who = LIEGE value >= -20 }
-			is_voter = yes
-			NOT = {
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
-				}
-			}
-		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			pacifist = yes
 			NOT = {
@@ -9360,37 +8994,45 @@ faction_powerful_vassal_takeover = {
 				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
+			factor = 0.5
+			ROOT = {
+				liege = {
+					any_owned_bloodline = {
+						has_bloodline_flag = bloodline_less_factions
+					}
+				}
+			}
+		}
+		mult_modifier = {
 			factor = 1000
 			has_opinion_modifier = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			opinion = { who = LIEGE value < -10 }
-		}
-		modifier = {
-			factor = 2.0
-			opinion = { who = LIEGE value < -50 }
-		}
-		modifier = {
-			factor = 4.0
-			opinion = { who = LIEGE value < -75 }
-		}
-
-		modifier = {
-			factor = 0
-			NOR = {
-				has_opinion_modifier = { who = LIEGE modifier = opinion_evil_tyrant }
-				has_opinion_modifier = { who = LIEGE modifier = opinion_tyrant }
+			opinion = {
+				who = liege
+				value < -10
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
+			factor = 2.0
+			opinion = {
+				who = liege
+				value < -50
+			}
+		}
+		mult_modifier = {
+			factor = 4.0
+			opinion = {
+				who = liege
+				value < -75
+			}
+		}
+		mult_modifier = {
 			factor = 0.01
 			trait = content
 			NOT = {
@@ -9400,7 +9042,7 @@ faction_powerful_vassal_takeover = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			trait = imbecile
 			NOT = {
@@ -9410,7 +9052,7 @@ faction_powerful_vassal_takeover = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = inbred
 			NOT = {
@@ -9420,7 +9062,7 @@ faction_powerful_vassal_takeover = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			trait = craven
 			NOT = {
@@ -9430,7 +9072,7 @@ faction_powerful_vassal_takeover = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			OR = {
 				trait = slow
@@ -9443,55 +9085,55 @@ faction_powerful_vassal_takeover = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = just
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = impaler
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = ambitious
 		}
@@ -9500,7 +9142,10 @@ faction_powerful_vassal_takeover = {
 	success = {
 		holder_scope = {
 			FROM = {
-				has_opinion_modifier = { who = PREV modifier = opinion_abdicated }
+				has_opinion_modifier = {
+					who = PREV
+					modifier = opinion_abdicated
+				}
 			}
 		}
 	}
@@ -9509,6 +9154,7 @@ faction_powerful_vassal_takeover = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_powerful_vassal_takeover
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -9530,26 +9176,18 @@ faction_true_believers = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
-		is_adult = yes
-		has_character_flag = ai_flag_refuse_conversion
-		has_character_flag = flag_truebelievers_revolter
+		higher_tier_than = BARON
 		religion_group = pagan_group
 		is_reformed_religion = no
-
+		NOT = { religion = liege }
+		is_adult = yes
+		independent = no
+		prisoner = no
+		has_character_flag = ai_flag_refuse_conversion
+		has_character_flag = flag_truebelievers_revolter
 		is_incapable = no
-
-		primary_title = {
-			holy_order = no
-			higher_tier_than = BARON
-		}
-
-		liege = {
-			NOT = { religion = PREV	}
-		}
+		holy_order = no
 	}
 
 	# Target scope
@@ -9563,45 +9201,32 @@ faction_true_believers = {
 	allow_join = {
 		ROOT = {
 			is_ruler = yes
-		#	independent = no
-		#	is_landed = yes
-		#	is_adult = yes
-		#	is_incapable = no
-		#	prisoner = no
 			religion_group = pagan_group
 			is_reformed_religion = no
+		#	is_adult = yes
+		#	independent = no
+		#	is_landed = yes
+		#	is_incapable = no
+		#	prisoner = no
 		}
 	}
 
 	# AI creation weight
 	chance = {
-		factor = 1
-		modifier = {
-			factor = 1000
-			FROM = { has_character_flag = ai_flag_refuse_conversion }
-		}
+		factor = 1000
 
-		modifier = {
-			factor = 0
-			FROM = { NOT = { has_character_flag = ai_flag_refuse_conversion } }
+		trigger	= {
+			FROM = { has_character_flag = ai_flag_refuse_conversion }
 		}
 	}
 
 	# AI membership weight: ROOT is the prospective member. FROM is the faction leader. FROMFROM is the target title or character.
 	membership = {
-		factor = 1
+		factor = 1000
 
-		modifier = {
-			factor = 1000
+		trigger = {
+			religion = FROM
 			has_character_flag = ai_flag_refuse_conversion
-		}
-		modifier = {
-			factor = 0
-			NOT = { religion = FROM }
-		}
-		modifier = {
-			factor = 0
-			NOT = { has_character_flag = ai_flag_refuse_conversion }
 		}
 	}
 
@@ -9613,6 +9238,7 @@ faction_true_believers = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_true_believers
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM
@@ -9634,25 +9260,20 @@ faction_abrahamic_revolters = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_ruler = yes
-		independent = no
 		is_landed = yes
+		higher_tier_than = BARON
+		independent = no
 		is_adult = yes
 		has_character_flag = flag_abrahamic_revolter
-
+		prisoner = no
 		is_incapable = no
+		holy_order = no
+		mercenary = no
 
 		OR = {
 			religion_group = christian
 			religion_group = muslim
 			religion_group = jewish_group
-		}
-
-		primary_title = {
-			holy_order = no
-			mercenary = no
-			higher_tier_than = BARON
 		}
 
 		liege = {
@@ -9674,11 +9295,12 @@ faction_abrahamic_revolters = {
 	allow_join = {
 		ROOT = {
 			is_ruler = yes
-		#	independent = no
 		#	is_landed = yes
+		#	independent = no
 		#	is_adult = yes
 		#	is_incapable = no
 		#	prisoner = no
+
 			OR = {
 				religion_group = christian
 				religion_group = muslim
@@ -9689,15 +9311,10 @@ faction_abrahamic_revolters = {
 
 	# AI creation weight
 	chance = {
-		factor = 1
-		modifier = {
-			factor = 1000
-			FROM = { has_character_flag = flag_abrahamic_revolter }
-		}
+		factor = 1000
 
-		modifier = {
-			factor = 0
-			FROM = { NOT = { has_character_flag = flag_abrahamic_revolter } }
+		trigger = {
+			FROM = { has_character_flag = flag_abrahamic_revolter }
 		}
 	}
 
@@ -9717,6 +9334,7 @@ faction_abrahamic_revolters = {
 		FROM = {
 			any_faction_backer = {
 				faction = faction_abrahamic_revolters
+
 				reverse_opinion = {
 					modifier = opinion_grateful
 					who = FROM

--- a/CleanSlate/common/objectives/00_focuses.txt
+++ b/CleanSlate/common/objectives/00_focuses.txt
@@ -10,7 +10,7 @@
 focus_rulership = {
 	type = character
 
-	modifier_name = "RULERSHIP_FOCUS"
+	modifier_name = RULERSHIP_FOCUS
 
 	# Modifiers
 	stewardship = 3
@@ -41,34 +41,35 @@ focus_rulership = {
 	# AI Pick chance - based on personality, not needs!
 	chance = {
 		factor = 100
-		modifier = {
-			factor = 0
-			trait = stressed
+
+		trigger = {
+			NOT = { trait = stressed }
 		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.25
 			trait = depressed
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			OR = {
 				is_republic = yes
 				is_patrician = yes
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = arbitrary
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = just
 		}
@@ -78,7 +79,7 @@ focus_rulership = {
 focus_business = {
 	type = character
 
-	modifier_name = "BUSINESS_FOCUS"
+	modifier_name = BUSINESS_FOCUS
 
 	# Modifiers
 	stewardship = 2
@@ -110,31 +111,32 @@ focus_business = {
 	# AI Pick chance - based on personality, not needs!
 	chance = {
 		factor = 100
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.2
 			trait = stressed
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = depressed
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = charitable
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = greedy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			OR = {
 				is_republic = yes
@@ -147,7 +149,7 @@ focus_business = {
 focus_seduction = {
 	type = character
 
-	modifier_name = "SEDUCTION_FOCUS"
+	modifier_name = SEDUCTION_FOCUS
 
 	# Modifiers
 	intrigue = 2
@@ -160,16 +162,17 @@ focus_seduction = {
 
 	allow = {
 		is_adult = yes
+		is_incapable = no
+		is_ascetic_trigger = no
 
 		NOR = {
-			is_incapable = yes
 			trait = celibate
 			trait = eunuch
-			is_ascetic_trigger = yes
 		}
 
 		custom_tooltip = {
 			text = is_not_ascetic
+
 			NOR = {
 				has_character_modifier = hindu_ascetic
 				has_character_modifier = buddhist_ascetic
@@ -182,93 +185,84 @@ focus_seduction = {
 	chance = {
 		factor = 50
 
-		modifier = {
-			factor = 0
-			trait = chaste
-		}
-		modifier = {
-			factor = 0
-			has_game_rule = {
-				name = ai_seduction
-				value = off
+		trigger = {
+			NOR = {
+				has_game_rule = {
+					name = ai_seduction
+					value = off
+				}
+				trait = chaste
 			}
 		}
 
 		modifier = {
 			factor = 0.01 # Faithful spouse/consort
-			OR = {
-				AND = {
-					is_married = yes
-					any_spouse = {
-						is_lover = ROOT
-					}
-				}
-				AND = {
-					is_consort = yes
-					consort = {
-						is_lover = ROOT
-					}
+
+			any_lover = {
+				OR = {
+					is_married = ROOT
+					is_consort = ROOT
 				}
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = shy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = ugly
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = uncouth
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = honest
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = gregarious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = cruel
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = hedonist
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = fair
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = groomed
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5.0
 			trait = lustful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_character_modifier = african_adulthood_rites_3
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trigger_if = {
 				limit = {
@@ -313,7 +307,7 @@ focus_seduction = {
 focus_intrigue = {
 	type = character
 
-	modifier_name = "INTRIGUE_FOCUS"
+	modifier_name = INTRIGUE_FOCUS
 
 	# Modifiers
 	intrigue = 3
@@ -333,18 +327,17 @@ focus_intrigue = {
 	chance = {
 		factor = 100
 
-		modifier = {
-			factor = 0
-			has_game_rule = {
-				name = ai_intrigue
-				value = off
+		trigger = {
+			NOR = {
+				has_game_rule = {
+					name = ai_intrigue
+					value = off
+				}
+				trait = honest
 			}
 		}
-		modifier = {
-			factor = 0
-			trait = honest
-		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.25
 			NOR = {
 				trait = amateurish_plotter
@@ -353,47 +346,47 @@ focus_intrigue = {
 				trait = elusive_shadow
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = trusting
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = wroth
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = envious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = cruel
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5.0
 			trait = paranoid
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			trait = deceitful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_character_modifier = african_adulthood_rites_3
 		}
@@ -416,7 +409,7 @@ focus_intrigue = {
 focus_hunting = {
 	type = character
 
-	modifier_name = "HUNTING_FOCUS"
+	modifier_name = HUNTING_FOCUS
 
 	# Modifiers
 	martial = 2
@@ -428,12 +421,9 @@ focus_hunting = {
 
 	allow = {
 		is_adult = yes
-
-		NOR = {
-			is_incapable = yes
-			pacifist = yes
-			prisoner = yes
-		}
+		is_incapable = no
+		pacifist = no
+		prisoner = no
 	}
 
 	# Focuses have no success conditions
@@ -453,37 +443,37 @@ focus_hunting = {
 	chance = {
 		factor = 100
 
-		modifier = {
-			factor = 0
-			trait = infirm
+		trigger = {
+			NOT = { trait = infirm }
 		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.2
 			is_female = yes
 			NOT = { has_religion_feature = religion_matriarchal }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			is_female = no
 			has_religion_feature = religion_matriarchal
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = craven
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = hunter
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = falconer
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_character_modifier = african_adulthood_rites_2
 		}
@@ -493,7 +483,7 @@ focus_hunting = {
 focus_war = {
 	type = character
 
-	modifier_name = "WAR_FOCUS"
+	modifier_name = WAR_FOCUS
 
 	# Modifiers
 	martial = 3
@@ -526,12 +516,10 @@ focus_war = {
 	chance = {
 		factor = 100
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.1
 			is_female = yes
-			NOT = {
-				trait = shieldmaiden
-			}
+			NOT = { trait = shieldmaiden }
 		}
 		modifier = {
 			factor = 0.1
@@ -539,52 +527,50 @@ focus_war = {
 			has_religion_feature = religion_matriarchal
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			trait = craven
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
-			NOT = {
-				OR = {
-					trait = misguided_warrior
-					trait = tough_soldier
-					trait = skilled_tactician
-					trait = brilliant_strategist
-				}
+			NOR = {
+				trait = misguided_warrior
+				trait = tough_soldier
+				trait = skilled_tactician
+				trait = brilliant_strategist
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			is_feudal = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			is_tribal = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			is_nomadic = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = wroth
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = duelist
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_character_modifier = african_adulthood_rites_2
 		}
@@ -594,7 +580,7 @@ focus_war = {
 focus_carousing = {
 	type = character
 
-	modifier_name = "CAROUSING_FOCUS"
+	modifier_name = CAROUSING_FOCUS
 
 	# Modifiers
 	diplomacy = 3
@@ -608,15 +594,19 @@ focus_carousing = {
 		prisoner = no
 		is_incapable = no
 
-		OR = {
-			NOT = { religion_group = muslim }
-			trait = decadent
-			trait = hedonist
-			trait = drunkard
+		trigger_if = {
+			limit = { religion_group = muslim }
+
+			OR = {
+				trait = decadent
+				trait = hedonist
+				trait = drunkard
+			}
 		}
 
 		custom_tooltip = {
 			text = is_not_ascetic
+
 			NOR = {
 				has_character_modifier = hindu_ascetic
 				has_character_modifier = buddhist_ascetic
@@ -628,35 +618,36 @@ focus_carousing = {
 	# AI Pick chance - based on personality, not needs!
 	chance = {
 		factor = 100
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.25
 			trait = shy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = temperate
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = diligent
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = slothful
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = gluttonous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = hedonist
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = drunkard
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_character_modifier = african_adulthood_rites_1
 		}
@@ -679,7 +670,7 @@ focus_carousing = {
 focus_family = {
 	type = character
 
-	modifier_name = "FAMILY_FOCUS"
+	modifier_name = FAMILY_FOCUS
 
 	# Modifiers
 	diplomacy = 2
@@ -712,7 +703,8 @@ focus_family = {
 	# AI Pick chance - based on personality, not needs!
 	chance = {
 		factor = 100
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.01
 			NOT = {
 				any_sibling = {
@@ -725,64 +717,62 @@ focus_family = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			age < 25
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			is_female = no
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = gregarious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.75
 			trait = proud
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			trait = humble
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = gardener
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = craven
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = shy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = infirm
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = kind
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_character_modifier = african_adulthood_rites_1
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			is_female = yes
-			NOT = {
-				trait = shieldmaiden
-			}
+			NOT = { trait = shieldmaiden }
 		}
 	}
 }
@@ -790,7 +780,7 @@ focus_family = {
 focus_scholarship = {
 	type = character
 
-	modifier_name = "SCHOLARSHIP_FOCUS"
+	modifier_name = SCHOLARSHIP_FOCUS
 
 	# Modifiers
 	learning = 3
@@ -819,39 +809,39 @@ focus_scholarship = {
 	# AI Pick chance - based on personality, not needs!
 	chance = {
 		factor = 100
-		modifier = {
-			factor = 0
-			trait = imbecile
+
+		trigger = {
+			NOR = {
+				trait = inbred
+				trait = imbecile
+			}
 		}
-		modifier = {
-			factor = 0
-			trait = inbred
-		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.25
 			trait = wroth
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = craven
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = cynical
 			OR = {
@@ -861,15 +851,15 @@ focus_scholarship = {
 				trait = mastermind_theologian
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = scholar
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			is_theocracy = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_character_modifier = african_adulthood_rites_4
 		}
@@ -879,7 +869,7 @@ focus_scholarship = {
 focus_theology = {
 	type = character
 
-	modifier_name = "THEOLOGY_FOCUS"
+	modifier_name = THEOLOGY_FOCUS
 
 	# Modifiers
 	learning = 2
@@ -918,43 +908,39 @@ focus_theology = {
 	chance = {
 		factor = 100
 
-		modifier = {
-			factor = 0
-			trait = imbecile
+		trigger = {
+			NOR = {
+				trait = inbred
+				trait = imbecile
+				trait = cynical
+			}
 		}
-		modifier = {
-			factor = 0
-			trait = inbred
-		}
-		modifier = {
-			factor = 0
-			trait = cynical
-		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.25
 			trait = wroth
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = ambitious
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			trait = brave
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = craven
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			trait = content
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			trait = patient
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			OR = {
 				trait = detached_priest
@@ -963,19 +949,19 @@ focus_theology = {
 				trait = mastermind_theologian
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = mystic
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			trait = zealous
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			is_theocracy = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			has_character_modifier = african_adulthood_rites_4
 		}

--- a/CleanSlate/common/objectives/00_plots.txt
+++ b/CleanSlate/common/objectives/00_plots.txt
@@ -19,33 +19,31 @@ plot_gain_title = {
 	potential = {
 		always = no # Disabled for being too similar to the factions
 
-		prisoner = no
-		age >= 16
-		is_ruler = yes
-		independent = no
 		is_landed = yes
-		primary_title = { higher_tier_than = BARON }
+		higher_tier_than = BARON
+		independent = no
+		is_adult = yes
+		prisoner = no
+		is_incapable = no
+		NOT = { trait = imbecile }
 
-		NOR = {
-			is_incapable = yes
-			trait = imbecile
-		}
+		trigger_if = {
+			limit = {
+				NOT = { has_dlc = "Conclave" }
 
-		OR = {
+				crownlaw_title = {
+					always = yes
+				}
+			}
+
 			crownlaw_title = {
 				NOR = {
 					has_law = crown_authority_3
 					has_law = crown_authority_4
 				}
 			}
-
-			# Does not have a crownlaw title
-			NOT = {
-				crownlaw_title = {
-					always = yes
-				}
-			}
-
+		}
+		trigger_else = {
 			# Plot against top liege or king
 			OR = {
 				top_liege = {
@@ -53,9 +51,7 @@ plot_gain_title = {
 				}
 				liege = {
 					character = ROOT
-					primary_title = {
-						tier = KING
-					}
+					tier = KING
 				}
 			}
 		}
@@ -66,7 +62,7 @@ plot_gain_title = {
 	allow = {
 		holder_scope = {
 			NOR = {
-				spouse = { character = FROM }
+				is_married = FROM
 				reverse_has_truce = FROM
 			}
 		}
@@ -100,7 +96,7 @@ plot_gain_title = {
 				is_titular = no
 
 				holder_scope = {
-					overlord_of = FROM
+					is_liege_of = FROM
 				}
 
 				# Title is plotter's de jure kingdom title
@@ -124,9 +120,7 @@ plot_gain_title = {
 	effect = {
 		FROM = {
 			if = {
-				limit = {
-					intrigue < 10
-				}
+				limit = { intrigue < 10 }
 				change_intrigue = 1
 			}
 			any_plot_backer = {
@@ -147,7 +141,7 @@ plot_gain_title = {
 	abort = {
 		OR = {
 			holder_scope = {
-				spouse = { character = FROM }
+				is_married = FROM
 			}
 			FROM = {
 				OR = {
@@ -171,18 +165,49 @@ plot_gain_title = {
 	chance = {
 		factor = 50
 
-		modifier = {
-			factor = 0
-			FROM = {
-				ai = yes
-				war = yes
+		trigger = {
+			trigger_if = {
+				limit = { FROM = { ai = yes } } # Needed for some reason (maybe a bug)
+
+				FROM = {
+					war = no
+
+					trigger_if = {
+						limit = {
+							OR = {
+								trait = envious
+								trait = deceitful
+								trait = ambitious
+							}
+						}
+						ROOT = {
+							holder_scope = {
+								reverse_opinion = {
+									who = FROM
+									value < 50
+								}
+							}
+						}
+					}
+					trigger_else = {
+						ROOT = {
+							holder_scope = {
+								reverse_opinion = {
+									who = FROM
+									value < 25
+								}
+							}
+						}
+					}
+				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -191,36 +216,17 @@ plot_gain_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { trait = kind }
 		}
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 50 }
-				OR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = LIEGE value >= 25 }
-				NOR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
-				opinion = { who = LIEGE value >= 0 }
+				opinion = {
+					who = liege
+					value >= 0
+				}
 				NOR = {
 					trait = envious
 					trait = deceitful
@@ -228,10 +234,13 @@ plot_gain_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
-				opinion = { who = LIEGE value >= 25 }
+				opinion = {
+					who = liege
+					value >= 25
+				}
 				NOR = {
 					trait = envious
 					trait = deceitful
@@ -239,35 +248,46 @@ plot_gain_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -50 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = LIEGE value < -75 } }
+			FROM = {
+				opinion = {
+					who = liege
+					value < -75
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_smart_trigger = yes }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism
 			factor = 2.0
 			holder_scope = {
 				NOT = { dynasty = FROM }
+
 				top_liege = {
 					higher_tier_than = COUNT
 					dynasty = PREV
@@ -275,11 +295,12 @@ plot_gain_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism
 			factor = 2.0
 			holder_scope = {
 				NOT = { dynasty = FROM }
+
 				top_liege = {
 					higher_tier_than = COUNT
 					dynasty = PREV
@@ -287,7 +308,7 @@ plot_gain_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			# Secondary title of highest held tier
 			is_primary_holder_title = no
@@ -296,7 +317,7 @@ plot_gain_title = {
 			is_titular = no
 
 			holder_scope = {
-				overlord_of = FROM
+				is_liege_of = FROM
 			}
 
 			# Title is plotter's de jure kingdom title
@@ -320,25 +341,23 @@ plot_gain_vassal_title = {
 	# ROOT is plotter
 	potential = {
 		is_playable = yes
+		is_adult = yes
 		prisoner = no
 		is_patrician = no
 		is_merchant_republic = no
-		is_adult = yes
+		is_incapable = no
 
 		primary_title = {
 			higher_tier_than = COUNT
 			temporary = no
 		}
 
-		NOR = {
-			is_incapable = yes
-			has_landed_title = e_china_west_governor
-		}
-
 		trigger_if = {
 			limit = { ai = yes }
 			war = no
 		}
+
+		NOT = { has_landed_title = e_china_west_governor }
 	}
 
 	# Title scope
@@ -481,6 +500,7 @@ plot_gain_vassal_title = {
 				# Count title outside a Duke's duchy
 				AND = {
 					tier = COUNT
+
 					holder_scope = {
 						tier = DUKE
 						ROOT = {
@@ -492,6 +512,7 @@ plot_gain_vassal_title = {
 				# Duke with no count titles
 				AND = {
 					tier = DUKE
+
 					holder_scope = {
 						NOT = {
 							any_demesne_title = {
@@ -521,6 +542,7 @@ plot_gain_vassal_title = {
 				# Count titles in ruler's primary duchy
 				AND = {
 					tier = COUNT
+
 					location = {
 						duchy = {
 							holder_scope = {
@@ -540,6 +562,7 @@ plot_gain_vassal_title = {
 				# Count's secondary county
 				AND = {
 					tier = COUNT
+
 					location = {
 						is_capital = no
 					}
@@ -549,7 +572,6 @@ plot_gain_vassal_title = {
 					}
 				}
 
-				# Bloodline
 				FROM = {
 					any_owned_bloodline = {
 						has_bloodline_flag = bloodline_revocation_plot
@@ -583,18 +605,53 @@ plot_gain_vassal_title = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0
-			FROM = {
-				ai = yes
-				war = yes
+		trigger = {
+			trigger_if = {
+				limit = { FROM = { ai = yes } } # Needed for some reason (maybe a bug)
+
+				holder_scope = {
+					FROM = {
+						war = no
+
+						trigger_if = {
+							limit = { dynasty = PREV }
+
+							opinion = {
+								who = PREV
+								value < 0
+							}
+						}
+
+						trigger_if = {
+							limit = {
+								OR = {
+									trait = envious
+									trait = deceitful
+									trait = ambitious
+								}
+							}
+
+							opinion = {
+								who = PREV
+								value < 50
+							}
+						}
+						trigger_else = {
+							opinion = {
+								who = PREV
+								value < 25
+							}
+						}
+					}
+				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -603,44 +660,17 @@ plot_gain_vassal_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { trait = kind }
 		}
-		modifier = {
-			factor = 0
-			FROM = {
-				family = ROOT
-				opinion = { who = ROOT value >= 0 }
-			}
-		}
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = ROOT value >= 50 }
-				OR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-
-		}
-		modifier = {
-			factor = 0
-			FROM = {
-				opinion = { who = ROOT value >= 25 }
-				NOR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			FROM = {
-				opinion = { who = ROOT value >= 25 }
+				opinion = {
+					who = ROOT
+					value >= 25
+				}
 				OR = {
 					trait = envious
 					trait = deceitful
@@ -648,10 +678,13 @@ plot_gain_vassal_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.25
 			FROM = {
-				opinion = { who = ROOT value >= 0 }
+				opinion = {
+					who = ROOT
+					value >= 0
+				}
 				NOR = {
 					trait = envious
 					trait = deceitful
@@ -659,27 +692,37 @@ plot_gain_vassal_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = ROOT value < -50 } }
+			FROM = {
+				opinion = {
+					who = ROOT
+					value < -50
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			FROM = { opinion = { who = ROOT value < -75 } }
+			FROM = {
+				opinion = {
+					who = ROOT
+					value < -75
+				}
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_smart_trigger = yes }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -697,9 +740,12 @@ plot_kill_character = {
 	# FROMFROM is society
 	society_plot = {
 		ROOT = {
-			society_member_of = the_assassins
-			society_rank >= 2
+			society_rank = {
+				society = the_assassins
+				rank >= 2
+			}
 		}
+
 		OR = {
 			FROM = {
 				NOR = {
@@ -717,26 +763,20 @@ plot_kill_character = {
 	# Plotter scope
 	# ROOT is plotter
 	potential = {
+		is_adult = yes
 		prisoner = no
-		age >= 16
+		is_incapable = no
 
-		NOR = {
-			is_incapable = yes
+		trigger_if = {
+			limit = { ai = yes }
 
-			trigger_if = {
-				limit = { ai = yes }
-				OR = {
-					trait = honest
-					trait = kind
-					trait = just
-				}
+			NOR = {
+				trait = honest
+				trait = kind
+				trait = just
 			}
-		}
 
-		hidden_trigger = {
 			OR = {
-				ai = no # Human
-
 				# Pretender to a title
 				any_pretender_title = {
 					always = yes
@@ -747,7 +787,7 @@ plot_kill_character = {
 					always = yes
 				}
 
-				# Character's child is heir or pretender to a title that I don't hold
+				# Child is heir or pretender to a title I don't hold or may inherit
 				any_child = {
 					OR = {
 						any_pretender_title = {
@@ -762,19 +802,21 @@ plot_kill_character = {
 					}
 				}
 
-				# Spouse is pretender to a title
+				# Spouse is pretender to a title I don't hold
 				spouse = {
 					any_pretender_title = {
-						NOT = { current_heir = { character = ROOT } }
+						current_heir = { NOT = { character = ROOT } }
 					}
 					any_heir_title = {
 						NOT = { holder = ROOT }
 					}
 				}
 
-				# A lover of spouse...
+				# A lover of my spouse...
 				spouse = {
-					has_lover = yes
+					any_lover = {
+						NOT = { character = ROOT }
+					}
 				}
 
 				# Is nuts...
@@ -786,19 +828,20 @@ plot_kill_character = {
 
 	# FROM is plotter
 	target_potential = {
-		NOT = { any_spouse = { character = FROM } } # This case is covered by another plot
+		NOT = { is_married = FROM } # This case is covered by another plot
 	}
 
 	# Target allow trigger for when players target a specific character in the GUI
 	# ROOT is target
 	# FROM is plotter
 	player_allow = {
+		is_within_diplo_range = FROM
+		assassination_interaction_trigger = yes
+
 		NOR = {
 			is_child_of = FROM # Not my own children
 			has_blood_oath_with = FROM
 		}
-		is_within_diplo_range = FROM
-		assassination_interaction_trigger = yes
 	}
 
 	# Target character scope
@@ -811,8 +854,7 @@ plot_kill_character = {
 			is_child_of = FROM # Not my own children
 			has_blood_oath_with = FROM
 			is_friend = FROM
-
-			any_spouse = { character = FROM } # This case is covered by another plot
+			is_married = FROM # This case is covered by another plot
 
 			# Don't kill my lovers, or their children
 			FROM = {
@@ -838,12 +880,20 @@ plot_kill_character = {
 					any_pretender_title = {
 						current_heir = { character = ROOT }
 					}
-					OR = {
-						ai = no
-						trait = deceitful
-						trait = ambitious
-						trait = arbitrary
-						opinion = { who = ROOT value < 0 }
+
+					trigger_if = {
+						limit = { ai = yes }
+
+						OR = {
+							trait = deceitful
+							trait = ambitious
+							trait = arbitrary
+
+							opinion = {
+								who = ROOT
+								value < 0
+							}
+						}
 					}
 				}
 
@@ -852,17 +902,27 @@ plot_kill_character = {
 					any_heir_title = {
 						holder = ROOT
 					}
-					OR = {
-						ai = no
-						trait = deceitful
-						trait = ambitious
-						trait = arbitrary
-						opinion = { who = ROOT value < 0 }
+
+					trigger_if = {
+						limit = { ai = yes }
+
+						OR = {
+							trait = deceitful
+							trait = ambitious
+							trait = arbitrary
+
+							opinion = {
+								who = ROOT
+								value < 0
+							}
+						}
 					}
 				}
 
 				# Gets rid of obstacles in the way of a child's succession
 				AND = {
+					NOT = { is_close_relative = ROOT }
+
 					any_child = {
 						OR = {
 							any_pretender_title = {
@@ -873,7 +933,6 @@ plot_kill_character = {
 							}
 						}
 					}
-					NOT = { is_close_relative = ROOT }
 
 					trigger_if = {
 						limit = { ai = yes }
@@ -882,19 +941,24 @@ plot_kill_character = {
 							trait = deceitful
 							trait = ambitious
 							trait = arbitrary
-							opinion = { who = ROOT value < 0 }
+
+							opinion = {
+								who = ROOT
+								value < 0
+							}
 						}
 					}
 				}
 
 				# Get rid of the current heir to a title the character's spouse is a pretender to
 				AND = {
+					NOT = { is_close_relative = ROOT }
+
 					spouse = {
 						any_pretender_title = {
 							current_heir = { character = ROOT }
 						}
 					}
-					NOT = { is_close_relative = ROOT }
 
 					trigger_if = {
 						limit = { ai = yes }
@@ -903,19 +967,24 @@ plot_kill_character = {
 							trait = deceitful
 							trait = ambitious
 							trait = arbitrary
-							opinion = { who = ROOT value < 0 }
+
+							opinion = {
+								who = ROOT
+								value < 0
+							}
 						}
 					}
 				}
 
 				# Get rid of a ruler the spouse is heir to
 				AND = {
+					NOT = { is_close_relative = ROOT }
+
 					spouse = {
 						any_heir_title = {
 							holder = ROOT
 						}
 					}
-					NOT = { is_close_relative = ROOT }
 
 					trigger_if = {
 						limit = { ai = yes }
@@ -927,34 +996,46 @@ plot_kill_character = {
 
 							trigger_if = {
 								limit = { is_female = yes }
-								opinion = { who = ROOT value < -33 }
+
+								opinion = {
+									who = ROOT
+									value < -33
+								}
 							}
 							trigger_else = {
-								opinion = { who = ROOT value < 0 }
+								opinion = {
+									who = ROOT
+									value < 0
+								}
 							}
 						}
 					}
 				}
 
-				# A lover of spouse...
-				spouse = {
-					has_lover = yes
-					any_lover = {
-						character = ROOT
+				# A lover of my spouse...
+				AND = {
+					any_spouse = {
+						is_lover = ROOT
 					}
 
 					trigger_if = {
 						limit = { ai = yes }
-						opinion = { who = ROOT value < 0 }
+
+						opinion = {
+							who = ROOT
+							value < 0
+						}
 					}
 				}
 
 				# Go nuts...
 				AND = {
 					same_liege = ROOT
+
 					OR = {
 						trait = lunatic
 						trait = possessed
+
 						any_owned_bloodline = {
 							has_bloodline_flag = bloodline_murderous
 						}
@@ -962,9 +1043,7 @@ plot_kill_character = {
 				}
 
 				# Rivals
-				any_rival = {
-					character = ROOT
-				}
+				is_rival = ROOT
 
 				ROOT = { is_murder_quest_target_of_prev_trigger = yes }
 			}
@@ -982,13 +1061,14 @@ plot_kill_character = {
 
 	success = {
 		is_alive = no
-		FROM = { has_character_flag = murder_in_motion }
+
+		hidden_trigger = {
+			FROM = { has_character_flag = murder_in_motion }
+		}
 	}
 
 	effect = {
-		FROM = {
-			clr_character_flag = murder_in_motion
-		}
+		FROM = { clr_character_flag = murder_in_motion }
 	}
 
 	abort = {
@@ -1002,26 +1082,60 @@ plot_kill_character = {
 	chance = {
 		factor = 2
 
-		modifier = {
+		trigger = {
+			trigger_if = {
+				limit = { FROM = { ai = yes } } # Needed for some reason (maybe a bug)
+
+				is_pilgrim = no
+
+				FROM = {
+					trigger_if = {
+						limit = {
+							opinion = {
+								who = ROOT
+								value >= 25
+							}
+						}
+						ROOT = { is_murder_quest_target_of_prev_trigger = yes }
+					}
+					trigger_else_if = {
+						limit = {
+							opinion = {
+								who = ROOT
+								value >= 0
+							}
+							OR = {
+								trait = envious
+								trait = deceitful
+								trait = ambitious
+								ROOT = { is_murder_quest_target_of_prev_trigger = yes }
+							}
+						}
+					}
+				}
+			}
+		}
+
+		mult_modifier = {
 			factor = 50
 			FROM = { has_quest = quest_the_assassins_assassination }
 			is_quest_target_of = FROM
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.01
 			FROM = {
 				trait = content
-				NOT = { trait = lunatic }
-				NOT = { trait = possessed }
+				NOR = {
+					trait = lunatic
+					trait = possessed
+				}
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { pacifist = yes }
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = {
 				trait = envious
@@ -1035,60 +1149,44 @@ plot_kill_character = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = arbitrary }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = cruel }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 3.0
 			FROM = { trait = ambitious }
 		}
-		modifier = {
-			factor = 0
-			their_opinion = { who = FROM value >= 25 }
-			NOT = {
-				FROM = { ROOT = { is_murder_quest_target_of_prev_trigger = yes } } # MnM murder missions
-			}
-		}
-		modifier = {
-			factor = 0
-			their_opinion = { who = FROM value >= 0 }
-			FROM = {
-				NOR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-					ROOT = { is_murder_quest_target_of_prev_trigger = yes } # MnM murder missions
-				}
-			}
-		}
-		modifier = {
-			factor = 0
-			ROOT = {
-				is_pilgrim = yes
-			}
-		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			their_opinion = { who = FROM value < -25 }
+			reverse_opinion = {
+				who = FROM
+				value < -25
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			their_opinion = { who = FROM value < -50 }
+			reverse_opinion = {
+				who = FROM
+				value < -50
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			their_opinion = { who = FROM value < -75 }
+			reverse_opinion = {
+				who = FROM
+				value < -75
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism: Kill off members of powerful dynasties
 			factor = 2.0
 			top_liege = {
@@ -1097,26 +1195,25 @@ plot_kill_character = {
 				dynasty_realm_power >= 0.25
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism: Kill off members of powerful dynasties
 			factor = 2.0
 			top_liege = {
 				higher_tier_than = COUNT
 				dynasty = ROOT
-				dynasty_realm_power >= 0.4
+				dynasty_realm_power >= 0.40
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism: Kill off members of powerful dynasties
 			factor = 2.0
 			top_liege = {
 				higher_tier_than = COUNT
 				dynasty = ROOT
-				dynasty_realm_power >= 0.6
+				dynasty_realm_power >= 0.60
 			}
 		}
-
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			plot_target_char = {
 				sibling = FROM
@@ -1128,7 +1225,7 @@ plot_kill_character = {
 				top_liege = { character = father }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			plot_target_char = {
 				sibling = FROM
@@ -1141,15 +1238,14 @@ plot_kill_character = {
 				top_liege = { character = father }
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			any_owned_bloodline = { #Backstabbing family.
+			any_owned_bloodline = { # Backstabbing family
 				has_bloodline_flag = bloodline_murderous
 			}
 		}
 	}
 }
-
 
 # Get a spouse killed
 plot_kill_spouse = {
@@ -1183,19 +1279,16 @@ plot_kill_spouse = {
 	# Plotter scope
 	potential = {
 		prisoner = no
-		age >= 16
+		is_adult = yes
 		is_married = yes
+		is_incapable = no
 
-		NOR = {
-			is_incapable = yes
+		trigger_if = {
+			limit = { ai = yes }
 
-			trigger_if = {
-				limit = { ai = yes }
-
-				OR = {
-					trait = honest
-					trait = kind
-				}
+			NOR = {
+				trait = honest
+				trait = kind
 			}
 		}
 	}
@@ -1213,75 +1306,87 @@ plot_kill_spouse = {
 	allow = {
 		NOT = { is_lover = FROM }
 
-		OR = {
-			# Human
-			FROM = { ai = no }
+		trigger_if = {
+			limit = { FROM = { ai = yes } }
 
-			# Male plotter without sons wanting to kill an old/barren wife
-			AND = {
-				age >= 40
-				FROM = {
-					is_female = no
+			FROM = {
+				opinion = {
+					who = ROOT
+					value < -25
+				}
+			}
 
-					OR = {
-						is_ruler = yes
-						is_primary_heir = yes
-					}
+			OR = {
+				# Male plotter without sons wanting to kill an old/barren wife
+				AND = {
+					age >= 40
 
-					# No sons
-					NOT = {
-						any_child = {
-							is_alive = yes
-							is_female = no
+					FROM = {
+						is_female = no
+
+						OR = {
+							is_ruler = yes
+							is_primary_heir = yes
+						}
+
+						# No sons
+						NOT = {
+							any_child = {
+								is_alive = yes
+								is_female = no
+							}
+						}
+						opinion = {
+							who = ROOT
+							value < 50
 						}
 					}
-					opinion = { who = ROOT value < 50 }
 				}
-			}
 
-			# Female plotter disliking her husband but loving her child - the legal heir
-			FROM = {
-				is_female = yes
-				num_of_children >= 1
+				# Female plotter disliking her husband but loving her child - the legal heir
+				FROM = {
+					is_female = yes
+					num_of_children >= 1
 
-				any_child = {
-					is_alive = yes
-					any_heir_title = {
-						holder = ROOT
+					any_child = {
+						is_alive = yes
+						is_incapable = no
+
+						any_heir_title = {
+							holder = ROOT
+						}
+
+						reverse_opinion = {
+							who = FROM
+							value >= 75
+						}
 					}
-					is_incapable = no
-					their_opinion = { who = FROM value >= 75 }
 				}
-			}
 
-			# Spouse has a lover...
-			AND = {
-				has_lover = yes
-				any_lover = {
-					NOT = { character = FROM }
+				# Spouse has a lover...
+				AND = {
+					has_lover = yes
+
+					any_lover = {
+						NOT = { character = FROM }
+					}
 				}
-			}
 
-			# Insane plotter...
-			FROM = {
-				OR = {
-					trait = lunatic
-					trait = possessed
+				# Insane plotter...
+				FROM = {
+					OR = {
+						trait = lunatic
+						trait = possessed
+					}
 				}
-			}
-		}
-
-		FROM = {
-			trigger_if = {
-				limit = { ai = yes }
-				opinion = { who = ROOT value < -25 }
 			}
 		}
 	}
 
 	success = {
 		is_alive = no
-		hidden_tooltip = {
+
+		hidden_trigger = {
 			FROM = { has_character_flag = murder_in_motion }
 		}
 	}
@@ -1294,6 +1399,7 @@ plot_kill_spouse = {
 			if = {
 				limit = {
 					ai = no
+					is_ironman = yes
 				}
 				set_character_flag = achievement_spouse_killer
 			}
@@ -1314,76 +1420,101 @@ plot_kill_spouse = {
 	chance = {
 		factor = 10
 
-		modifier = {
-			factor = 0.01
-			FROM = { trait = content }
-		}
-		modifier = {
-			factor = 0.2
-			FROM = { pacifist = yes }
-		}
-		modifier = {
-			factor = 0
-			their_opinion = { who = FROM value >= 25 }
-		}
-		modifier = {
-			factor = 0
-			their_opinion = { who = FROM value >= 0 }
-			FROM = {
-				NOR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
+		trigger = {
+			trigger_if = {
+				limit = { FROM = { ai = yes } } # Needed for some reason (maybe a bug)
+
+				is_pilgrim = no
+
+				FROM = {
+					trigger_if = {
+						limit = {
+							OR = {
+								trait = envious
+								trait = deceitful
+								trait = ambitious
+							}
+						}
+						opinion = {
+							who = ROOT
+							value < 25
+						}
+					}
+					trigger_else = {
+						opinion = {
+							who = ROOT
+							value < 0
+						}
+					}
 				}
 			}
 		}
-		modifier = {
-			factor = 0
-			ROOT = {
-				is_pilgrim = yes
+
+		mult_modifier = {
+			factor = 0.01
+			FROM = { trait = content }
+		}
+		mult_modifier = {
+			factor = 0.2
+			FROM = { pacifist = yes }
+		}
+		mult_modifier = {
+			factor = 1.5
+			reverse_opinion = {
+				who = FROM
+				value < -25
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			their_opinion = { who = FROM value < -25 }
+			reverse_opinion = {
+				who = FROM
+				value < -50
+			}
 		}
-		modifier = {
-			factor = 1.5
-			their_opinion = { who = FROM value < -50 }
-		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			their_opinion = { who = FROM value < -75 }
+			reverse_opinion = {
+				who = FROM
+				value < -75
+			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = paranoid }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			FROM = { trait = lunatic }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			FROM = { trait = possessed }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			FROM = { trait = intricate_webweaver }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { trait = elusive_shadow }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
-			age = 40
+			age >= 40
+
+			OR = {
+				is_married = FROM
+				is_consort = FROM
+			}
+
 			FROM = {
 				is_female = no
+
 				NOT = {
 					any_child = {
 						is_alive = yes
@@ -1392,7 +1523,7 @@ plot_kill_spouse = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 50
 			FROM = { has_quest = quest_the_assassins_assassination }
 			is_quest_target_of = FROM
@@ -1409,35 +1540,33 @@ plot_weaken_fellow_vassal = {
 	potential = {
 		always = no # v2.21 - Disabled - not working well
 
+		is_landed = yes
+		higher_tier_than = BARON
+		independent = no
+		is_adult = yes
 		prisoner = no
 		is_patrician = no
-		is_ruler = yes
-		independent = no
-		is_landed = yes
-		age >= 16
+		is_incapable = no
+		NOT = { trait = imbecile }
 
 		liege = {
 			is_merchant_republic = no
 			is_patrician = no
 		}
 
-		primary_title = { higher_tier_than = BARON }
+		trigger_if = {
+			limit = {
+				NOT = { has_dlc = "Conclave" }
 
-		NOR = {
-			is_incapable = yes
-			trait = imbecile
-		}
+				crownlaw_title = {
+					always = yes
+				}
+			}
 
-		OR = {
 			crownlaw_title = {
 				NOR = {
 					has_law = crown_authority_3
 					has_law = crown_authority_4
-				}
-			}
-			NOT = {
-				crownlaw_title = {
-					always = yes
 				}
 			}
 		}
@@ -1447,8 +1576,8 @@ plot_weaken_fellow_vassal = {
 	# ROOT is title
 	# FROM is plotter
 	allow = {
-		is_vice_royalty = no
 		higher_tier_than = COUNT
+		is_vice_royalty = no
 		is_primary_holder_title = no
 
 		current_heir = {
@@ -1456,19 +1585,16 @@ plot_weaken_fellow_vassal = {
 		}
 
 		holder_scope = {
+			tier = DUKE
 			independent = no
-			held_title_rating = FROM
+			held_title_rating >= FROM
 			same_liege = FROM
 
 			NOR = {
 				reverse_has_truce = FROM
 				character = FROM
-				overlord_of = FROM
-				spouse = { character = FROM }
-				primary_title = { higher_tier_than = DUKE }
+				is_married = FROM
 			}
-
-			primary_title = { higher_tier_than = COUNT }
 
 			any_demesne_title = {
 				tier = ROOT
@@ -1477,8 +1603,10 @@ plot_weaken_fellow_vassal = {
 
 			any_vassal = {
 				tier = COUNT
+
 				any_demesne_title = {
 					tier = COUNT
+
 					dejure_liege_title = {
 						title = ROOT
 					}
@@ -1522,9 +1650,7 @@ plot_weaken_fellow_vassal = {
 	effect = {
 		FROM = {
 			if = {
-				limit = {
-					intrigue < 10
-				}
+				limit = { intrigue < 10 }
 				change_intrigue = 1
 			}
 			any_plot_backer = {
@@ -1544,7 +1670,7 @@ plot_weaken_fellow_vassal = {
 	abort = {
 		OR = {
 			holder_scope = {
-				spouse = { character = FROM }
+				is_married = FROM
 			}
 			FROM = {
 				OR = {
@@ -1570,18 +1696,49 @@ plot_weaken_fellow_vassal = {
 	chance = {
 		factor = 1
 
-		modifier = {
-			factor = 0
-			FROM = {
-				ai = yes
-				war = yes
+		trigger = {
+			trigger_if = {
+				limit = { FROM = { ai = yes } } # Needed for some reason (maybe a bug)
+
+				FROM = {
+					war = no
+
+					trigger_if = {
+						limit = {
+							OR = {
+								trait = envious
+								trait = deceitful
+								trait = ambitious
+							}
+						}
+						ROOT = {
+							holder_scope = {
+								reverse_opinion = {
+									who = FROM
+									value < 50
+								}
+							}
+						}
+					}
+					trigger_else = {
+						ROOT = {
+							holder_scope = {
+								reverse_opinion = {
+									who = FROM
+									value < 25
+								}
+							}
+						}
+					}
+				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -1590,15 +1747,18 @@ plot_weaken_fellow_vassal = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { trait = kind }
 		}
-		modifier = {
-			factor = 0
+		mult_modifier = {
+			factor = 0.2
 			ROOT = {
 				holder_scope = {
-					reverse_opinion = { who = FROM value >= 25 }
+					reverse_opinion = {
+						who = FROM
+						value >= 0
+					}
 				}
 			}
 			FROM = {
@@ -1609,11 +1769,14 @@ plot_weaken_fellow_vassal = {
 				}
 			}
 		}
-		modifier = {
-			factor = 0
+		mult_modifier = {
+			factor = 0.2
 			ROOT = {
 				holder_scope = {
-					reverse_opinion = { who = FROM value >= 50 }
+					reverse_opinion = {
+						who = FROM
+						value >= 25
+					}
 				}
 			}
 			FROM = {
@@ -1624,54 +1787,30 @@ plot_weaken_fellow_vassal = {
 				}
 			}
 		}
-		modifier = {
-			factor = 0.2
-			ROOT = {
-				holder_scope = {
-					reverse_opinion = { who = FROM value >= 0 }
-				}
-			}
-			FROM = {
-				NOR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
-			factor = 0.2
-			ROOT = {
-				holder_scope = {
-					reverse_opinion = { who = FROM value >= 25 }
-				}
-			}
-			FROM = {
-				OR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.25
 			ROOT = {
 				holder_scope = {
-					reverse_opinion = { who = FROM value < 0 }
+					reverse_opinion = {
+						who = FROM
+						value < 0
+					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			ROOT = {
 				holder_scope = {
-					reverse_opinion = { who = FROM value < -25 }
+					reverse_opinion = {
+						who = FROM
+						value < -25
+					}
 				}
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism
 			factor = 2.0
 			holder_scope = {
@@ -1682,7 +1821,7 @@ plot_weaken_fellow_vassal = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism
 			factor = 2.0
 			holder_scope = {
@@ -1693,7 +1832,7 @@ plot_weaken_fellow_vassal = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism
 			factor = 2.0
 			holder_scope = {
@@ -1705,19 +1844,19 @@ plot_weaken_fellow_vassal = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_smart_trigger = yes }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -1737,24 +1876,21 @@ plot_gain_liege_title = {
 	# ROOT is plotter
 	potential = {
 		is_playable = yes
-		prisoner = no
 		is_landed = yes
+		is_adult = yes
+		prisoner = no
 		independent = no
+		is_incapable = no
 		mercenary = no
-		age >= 16
+
+		NOR = {
+			trait = imbecile
+			is_parent_of = liege
+		}
 
 		OR = {
 			is_feudal = yes
 			is_tribal = yes
-		}
-
-		NOR = {
-			is_incapable = yes
-			trait = imbecile
-		}
-
-		liege = {
-			NOT = { is_parent_of = ROOT }
 		}
 	}
 
@@ -1778,6 +1914,7 @@ plot_gain_liege_title = {
 	allow = {
 		is_vice_royalty = no
 		NOT = { claimed_by = FROM }
+
 		current_heir = {
 			NOT = { character = FROM }
 		}
@@ -1806,13 +1943,11 @@ plot_gain_liege_title = {
 	# Title scope
 	# FROM is plotter
 	abort = {
-		OR = {
-			has_holder = no
+		trigger_if = {
+			limit = { has_holder = yes }
+
 			holder_scope = {
-				OR = {
-					character = FROM
-					is_playable = no
-				}
+				character = FROM
 			}
 		}
 	}
@@ -1829,18 +1964,41 @@ plot_gain_liege_title = {
 	chance = {
 		factor = 1 # Must always be an integer
 
-		modifier = {
-			factor = 0
-			FROM = {
-				ai = yes
-				war = yes
+		trigger = {
+			trigger_if = {
+				limit = { FROM = { ai = yes } } # Needed for some reason (maybe a bug)
+
+				FROM = {
+					war = no
+
+					trigger_if = {
+						limit = {
+							OR = {
+								trait = envious
+								trait = deceitful
+								trait = ambitious
+							}
+						}
+						opinion = {
+							who = liege
+							value < 50
+						}
+					}
+					trigger_else = {
+						opinion = {
+							who = liege
+							value < 25
+						}
+					}
+				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -1849,16 +2007,17 @@ plot_gain_liege_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { trait = kind }
 		}
-		modifier = {
-			factor = 0
-			holder_scope = {
-				reverse_opinion = { who = FROM value >= 25 }
-			}
+		mult_modifier = {
+			factor = 0.2
 			FROM = {
+				opinion = {
+					who = liege
+					value >= 0
+				}
 				NOR = {
 					trait = envious
 					trait = deceitful
@@ -1866,10 +2025,13 @@ plot_gain_liege_title = {
 				}
 			}
 		}
-		modifier = {
-			factor = 0
+		mult_modifier = {
+			factor = 0.2
 			holder_scope = {
-				reverse_opinion = { who = FROM value >= 50 }
+				reverse_opinion = {
+					who = FROM
+					value >= 25
+				}
 			}
 			FROM = {
 				OR = {
@@ -1879,49 +2041,30 @@ plot_gain_liege_title = {
 				}
 			}
 		}
-		modifier = {
-			factor = 0.2
-			holder_scope = {
-				reverse_opinion = { who = FROM value >= 0 }
-			}
+		mult_modifier = {
+			factor = 1.5
 			FROM = {
-				NOR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
+				opinion = {
+					who = liege
+					value < -50
 				}
 			}
 		}
-		modifier = {
-			factor = 0.2
-			holder_scope = {
-				reverse_opinion = { who = FROM value >= 25 }
-			}
+		mult_modifier = {
+			factor = 1.5
 			FROM = {
-				OR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
+				opinion = {
+					who = liege
+					value < -75
 				}
 			}
 		}
-		modifier = {
-			factor = 1.5
-			holder_scope = {
-				reverse_opinion = { who = FROM value < -50 }
-			}
-		}
-		modifier = {
-			factor = 1.5
-			holder_scope = {
-				reverse_opinion = { who = FROM value < -75 }
-			}
-		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism
 			factor = 2.0
 			holder_scope = {
 				NOT = { dynasty = FROM }
+
 				top_liege = {
 					higher_tier_than = COUNT
 					dynasty = PREV
@@ -1929,11 +2072,12 @@ plot_gain_liege_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			# Subtle balance against nepotism
 			factor = 2.0
 			holder_scope = {
 				NOT = { dynasty = FROM }
+
 				top_liege = {
 					higher_tier_than = COUNT
 					dynasty = PREV
@@ -1942,19 +2086,19 @@ plot_gain_liege_title = {
 			}
 		}
 
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_smart_trigger = yes }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -1968,20 +2112,16 @@ plot_gain_fellow_vassal_title = {
 
 	# Plotter scope
 	potential = {
-		is_playable = yes
-		prisoner = no
 		is_landed = yes
 		independent = no
-		age >= 16
+		is_adult = yes
+		prisoner = no
+		is_incapable = no
+		NOT = { trait = imbecile }
 
 		OR = {
 			is_feudal = yes
 			is_tribal = yes
-		}
-
-		NOR = {
-			is_incapable = yes
-			trait = imbecile
 		}
 	}
 
@@ -2001,9 +2141,10 @@ plot_gain_fellow_vassal_title = {
 				}
 			}
 		}
+
 		holder_scope = {
-			is_ruler = yes
 			is_landed = yes
+			higher_tier_than = BARON
 			independent = no
 			same_liege = FROM
 
@@ -2016,8 +2157,6 @@ plot_gain_fellow_vassal_title = {
 				is_feudal = yes
 				is_tribal = yes
 			}
-
-			primary_title = { higher_tier_than = BARON }
 		}
 	}
 
@@ -2041,9 +2180,7 @@ plot_gain_fellow_vassal_title = {
 	effect = {
 		FROM = {
 			if = {
-				limit = {
-					intrigue < 10
-				}
+				limit = { intrigue < 10 }
 				change_intrigue = 1
 			}
 			any_plot_backer = {
@@ -2060,11 +2197,12 @@ plot_gain_fellow_vassal_title = {
 	# Title scope
 	# FROM is plotter
 	abort = {
-		OR = {
+		trigger_if = {
+			limit = { has_holder = yes }
+
 			holder_scope = {
 				character = FROM
 			}
-			has_holder = no
 		}
 	}
 
@@ -2077,18 +2215,41 @@ plot_gain_fellow_vassal_title = {
 	chance = {
 		factor = 1 # Must be an integer
 
-		modifier = {
-			factor = 0
-			FROM = {
-				ai = yes
-				war = yes
+		trigger = {
+			trigger_if = {
+				limit = { FROM = { ai = yes } } # Needed for some reason (maybe a bug)
+
+				FROM = {
+					war = no
+
+					trigger_if = {
+						limit = {
+							OR = {
+								trait = envious
+								trait = deceitful
+								trait = ambitious
+							}
+						}
+						opinion = {
+							who = liege
+							value < 50
+						}
+					}
+					trigger_else = {
+						opinion = {
+							who = liege
+							value < 25
+						}
+					}
+				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -2097,14 +2258,17 @@ plot_gain_fellow_vassal_title = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { trait = kind }
 		}
-		modifier = {
-			factor = 0
+		mult_modifier = {
+			factor = 0.2
 			holder_scope = {
-				reverse_opinion = { who = FROM value >= 25 }
+				reverse_opinion = {
+					who = FROM
+					value >= 0
+				}
 			}
 			FROM = {
 				NOR = {
@@ -2114,10 +2278,13 @@ plot_gain_fellow_vassal_title = {
 				}
 			}
 		}
-		modifier = {
-			factor = 0
+		mult_modifier = {
+			factor = 0.2
 			holder_scope = {
-				reverse_opinion = { who = FROM value >= 50 }
+				reverse_opinion = {
+					who = FROM
+					value >= 25
+				}
 			}
 			FROM = {
 				OR = {
@@ -2127,61 +2294,41 @@ plot_gain_fellow_vassal_title = {
 				}
 			}
 		}
-		modifier = {
-			factor = 0.2
-			holder_scope = {
-				reverse_opinion = { who = FROM value >= 0 }
-			}
-			FROM = {
-				NOR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
-			factor = 0.2
-			holder_scope = {
-				reverse_opinion = { who = FROM value >= 25 }
-			}
-			FROM = {
-				OR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			ROOT = {
 				holder_scope = {
-					reverse_opinion = { who = FROM value < -50 }
+					reverse_opinion = {
+						who = FROM
+						value < -50
+					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			ROOT = {
 				holder_scope = {
-					reverse_opinion = { who = FROM value < -75 }
+					reverse_opinion = {
+						who = FROM
+						value < -75
+					}
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_smart_trigger = yes }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
@@ -2198,19 +2345,25 @@ plot_seize_trade_post = {
 		has_dlc = "The Republic"
 		is_patrician = yes
 		is_merchant_republic = no
+		is_adult = yes
 		prisoner = no
-		age >= 16
-
-		NOR = {
-			is_incapable = yes
-			trait = imbecile
-		}
+		is_incapable = no
+		NOT = { trait = imbecile }
 	}
 
 	# Target scope
 	# FROM is plotter
 	allow = {
 		has_trade_post = yes
+
+		any_neighbor_province = {
+			has_trade_post = yes
+
+			trade_post_owner = {
+				character = FROM
+			}
+		}
+
 		trade_post_owner = {
 			num_of_trade_post_diff = {
 				character = FROM
@@ -2219,7 +2372,7 @@ plot_seize_trade_post = {
 
 			OR = {
 				same_liege = FROM
-				any_vassal = { character = FROM }
+				is_liege_of = FROM
 			}
 
 			NOR = {
@@ -2231,18 +2384,7 @@ plot_seize_trade_post = {
 			}
 
 			# Only if there is no non-aggression-pact with the trade post owner
-			FROM = {
-				NOT = {
-					has_non_aggression_pact_with = PREV
-				}
-			}
-		}
-
-		any_neighbor_province = {
-			has_trade_post = yes
-			trade_post_owner = {
-				character = FROM
-			}
+			NOT = { has_non_aggression_pact_with = FROM }
 		}
 	}
 
@@ -2263,18 +2405,49 @@ plot_seize_trade_post = {
 	chance = {
 		factor = 1 # Must be an integer
 
-		modifier = {
-			factor = 0
-			FROM = {
-				ai = yes
-				war = yes
+		trigger = {
+			trigger_if = {
+				limit = { FROM = { ai = yes } } # Needed for some reason (maybe a bug)
+
+				FROM = {
+					war = no
+
+					trigger_if = {
+						limit = {
+							OR = {
+								trait = envious
+								trait = deceitful
+								trait = ambitious
+							}
+						}
+						ROOT = {
+							trade_post_owner = {
+								reverse_opinion = {
+									who = FROM
+									value < 50
+								}
+							}
+						}
+					}
+					trigger_else = {
+						ROOT = {
+							trade_post_owner = {
+								reverse_opinion = {
+									who = FROM
+									value < 25
+								}
+							}
+						}
+					}
+				}
 			}
 		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 0.01
 			FROM = { trait = content }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = {
 				OR = {
@@ -2283,16 +2456,16 @@ plot_seize_trade_post = {
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.2
 			FROM = { trait = kind }
 		}
-		modifier = {
-			factor = 0
-			ROOT = {
-				holder_scope = {
-					NOT = { character = FROM }
-					reverse_opinion = { who = FROM value >= 25 }
+		mult_modifier = {
+			factor = 0.2
+			trade_post_owner = {
+				reverse_opinion = {
+					who = FROM
+					value >= 0
 				}
 			}
 			FROM = {
@@ -2303,12 +2476,12 @@ plot_seize_trade_post = {
 				}
 			}
 		}
-		modifier = {
-			factor = 0
-			ROOT = {
-				holder_scope = {
-					NOT = { character = FROM }
-					reverse_opinion = { who = FROM value >= 50 }
+		mult_modifier = {
+			factor = 0.2
+			trade_post_owner = {
+				reverse_opinion = {
+					who = FROM
+					value >= 25
 				}
 			}
 			FROM = {
@@ -2319,80 +2492,46 @@ plot_seize_trade_post = {
 				}
 			}
 		}
-		modifier = {
-			factor = 0.2
-			ROOT = {
-				holder_scope = {
-					NOT = { character = FROM }
-					reverse_opinion = { who = FROM value >= 0 }
-				}
-			}
-			FROM = {
-				OR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
-			factor = 0.2
-			ROOT = {
-				holder_scope = {
-					NOT = { character = FROM }
-					reverse_opinion = { who = FROM value >= 25 }
-				}
-			}
-			FROM = {
-				NOR = {
-					trait = envious
-					trait = deceitful
-					trait = ambitious
-				}
-			}
-		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			ROOT = {
-				holder_scope = {
-					NOT = { character = FROM }
-					reverse_opinion = { who = FROM value < -50 }
+			trade_post_owner = {
+				reverse_opinion = {
+					who = FROM
+					value < -50
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
-			ROOT = {
-				holder_scope = {
-					NOT = { character = FROM }
-					reverse_opinion = { who = FROM value < -75 }
+			trade_post_owner = {
+				reverse_opinion = {
+					who = FROM
+					value < -75
 				}
 			}
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 1.5
 			FROM = { is_smart_trigger = yes }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2.0
 			FROM = { trait = deceitful }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
 			FROM = { trait = ambitious }
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 4.0
-			ROOT = {
-				holder_scope = {
-					num_of_trade_post_diff = {
-						character = FROM
-						value >= 10
-					}
+			trade_post_owner = {
+				num_of_trade_post_diff = {
+					character = FROM
+					value >= 10
 				}
 			}
 		}
@@ -2409,10 +2548,10 @@ plot_assassins_collect_debt = {
 
 	# Plotter scope
 	potential = {
-		prisoner = no
-		is_adult = yes
 		society_member_of = the_assassins
 		has_quest = quest_the_assassins_collect_debt
+		prisoner = no
+		is_adult = yes
 		is_incapable = no
 	}
 
@@ -2460,6 +2599,7 @@ plot_assassins_collect_debt = {
 	abort = {
 		OR = {
 			is_alive = no
+
 			FROM = {
 				OR = {
 					is_alive = no

--- a/CleanSlate/common/objectives/00_zeus_ambitions.txt
+++ b/CleanSlate/common/objectives/00_zeus_ambitions.txt
@@ -15,20 +15,14 @@ obj_become_council_member = {
 
 	potential = {
 		has_dlc = "Conclave"
-		independent = no
-		prisoner = no
-		is_adult = yes
-		is_councillor = no
 		is_landed = yes
-
-		NOR = {
-			liege = {
-				spouse = {
-					character = ROOT
-				}
-			}
-			is_incapable = yes is_inaccessible_trigger = yes
-		}
+		is_adult = yes
+		independent = no
+		is_councillor = no
+		prisoner = no
+		is_incapable = no
+		is_inaccessible_trigger = no
+		NOT = { is_married = liege }
 
 		OR = {
 			can_hold_title = job_chancellor
@@ -138,18 +132,16 @@ obj_land_for_son = {
 		is_adult = yes
 		independent = no
 		is_nomadic = no
+		is_incapable = no
 
 		NOR = {
 			has_religion_feature = religion_matriarchal
-			is_incapable = yes
 			has_character_flag = land_for_son_successful
 		}
 
 		liege = {
 			is_nomadic = no
-			NOT = {
-				has_religion_feature = religion_matriarchal
-			}
+			NOT = { has_religion_feature = religion_matriarchal }
 		}
 
 		any_child = {
@@ -158,12 +150,9 @@ obj_land_for_son = {
 			is_adult = yes
 			is_heir = no
 			prisoner = no
-
-			NOR = {
-				is_incapable = yes
-				is_ascetic_trigger = yes
-				trait = eunuch
-			}
+			is_incapable = no
+			is_ascetic_trigger = no
+			NOT = { trait = eunuch }
 
 			liege = {
 				character = ROOT
@@ -241,7 +230,7 @@ obj_land_for_son = {
 		}
 		modifier = {
 			factor = 5
-			relative_income_to_liege = 0.50
+			relative_income_to_liege >= 0.50
 		}
 	}
 }
@@ -255,11 +244,8 @@ obj_land_for_daughter = {
 		is_adult = yes
 		independent = no
 		is_nomadic = no
-
-		NOR = {
-			is_incapable = yes
-			has_character_flag = land_for_daughter_successful
-		}
+		is_incapable = no
+		NOT = { has_character_flag = land_for_daughter_successful }
 
 		OR = {
 			has_religion_feature = religion_matriarchal
@@ -269,6 +255,7 @@ obj_land_for_daughter = {
 
 		liege = {
 			is_nomadic = no
+
 			OR = {
 				has_religion_feature = religion_matriarchal
 				has_religion_feature = religion_equal
@@ -282,11 +269,8 @@ obj_land_for_daughter = {
 			is_adult = yes
 			is_heir = no
 			prisoner = no
-
-			NOR = {
-				is_incapable = yes
-				is_ascetic_trigger = yes
-			}
+			is_incapable = no
+			is_ascetic_trigger = no
 
 			liege = {
 				character = ROOT
@@ -363,7 +347,7 @@ obj_land_for_daughter = {
 		}
 		modifier = {
 			factor = 5
-			relative_income_to_liege = 0.50
+			relative_income_to_liege >= 0.50
 		}
 	}
 }
@@ -373,13 +357,14 @@ obj_build_a_war_chest = {
 
 	potential = {
 		has_dlc = "Conclave"
-		NOT = { has_character_modifier = war_chest_timer }
-		is_nomadic = no
-		higher_tier_than = BARON
 		is_landed = yes
+		higher_tier_than = BARON
 		is_adult = yes
-		is_ruler = yes
+		is_nomadic = no
 		war = no
+		is_incapable = no
+		is_inaccessible_trigger = no
+		NOT = { has_character_modifier = war_chest_timer }
 
 		trigger_if = {
 			limit = { tier = COUNT }
@@ -395,11 +380,6 @@ obj_build_a_war_chest = {
 		}
 		trigger_else = {
 			wealth < 1000
-		}
-
-		NOR = {
-			is_incapable = yes
-			is_inaccessible_trigger = yes
 		}
 	}
 
@@ -428,7 +408,7 @@ obj_build_a_war_chest = {
 	effect = {
 		add_character_modifier = {
 			modifier = war_taxes
-			months = 60
+			years = 5
 		}
 		add_character_modifier = {
 		   modifier = war_chest_timer
@@ -524,31 +504,29 @@ obj_groom_an_heir = {
 
 	potential = {
 		has_dlc = "Conclave"
+		is_ruler = yes
 		higher_tier_than = BARON
+		is_adult = yes
+		is_incapable = no
+		is_inaccessible_trigger = no
 		holy_order = no
 		mercenary = no
-		is_adult = yes
-		is_ruler = yes
 
-		OR = {
-			NOT = { trait = eunuch }
-			any_child = {
-				is_alive = yes
-			}
+		trigger_if = {
+			limit = { trait = eunuch }
+			has_living_children = yes
 		}
 
 		NOR = {
-			is_incapable = yes
-			is_inaccessible_trigger = yes
-
 			any_child = {
 				is_adult = yes
+				is_incapable = no
+				is_ascetic_trigger = no
+
 				NOR = {
 					trait = bastard
 					trait = eunuch
 					trait = celibate
-					is_incapable = yes
-					is_ascetic_trigger = yes
 				}
 
 				trigger_if = {
@@ -590,43 +568,40 @@ obj_groom_an_heir = {
 	chance = {
 		factor = 100
 
-		modifier = {
-			factor = 0
-			trait = celibate
+		trigger = {
+			is_theocracy = no
+			NOT = { trait = celibate }
 		}
-		modifier = {
-			factor = 0
-			is_theocracy = yes
-		}
-		modifier = {
+
+		mult_modifier = {
 			factor = 10
 			has_focus = focus_family
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5
 			trait = bastard
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5
 			age >= 30
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5
 			age >= 45
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 5
 			government = nomadic_government
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 2
 			is_smart_trigger = yes
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = shy
 		}
-		modifier = {
+		mult_modifier = {
 			factor = 0.5
 			trait = chaste
 		}
@@ -635,7 +610,9 @@ obj_groom_an_heir = {
 	success = {
 		any_child = {
 			is_adult = yes
-			NOR = {
+			is_ascetic_trigger = no
+
+			NOT = {
 				custom_tooltip = {
 					text = bastard_eunuch_celibate_or_incapable_tt
 					OR = {
@@ -645,7 +622,6 @@ obj_groom_an_heir = {
 						is_incapable = yes
 					}
 				}
-				is_ascetic_trigger = yes
 			}
 
 			trigger_if = {
@@ -695,25 +671,23 @@ obj_groom_an_heir = {
 			any_child = {
 				limit = {
 					is_adult = yes
+					is_incapable = no
+					is_ascetic_trigger = no
 
 					NOR = {
 						trait = bastard
 						trait = eunuch
 						trait = celibate
-						is_incapable = yes
-						is_ascetic_trigger = yes
 					}
 
-					OR = {
-						is_female = no
-						AND = {
-							is_female = yes
-							ROOT = {
-								OR = {
-									has_law = true_cognatic_succession
-									has_law = enatic_succession
-									has_law = enatic_cognatic_succession
-								}
+					trigger_if = {
+						limit = { is_female = yes }
+
+						ROOT = {
+							OR = {
+								has_law = true_cognatic_succession
+								has_law = enatic_succession
+								has_law = enatic_cognatic_succession
 							}
 						}
 					}

--- a/CleanSlate/common/objectives/00_zeus_childhood_focuses.txt
+++ b/CleanSlate/common/objectives/00_zeus_childhood_focuses.txt
@@ -10,7 +10,7 @@
 focus_ch_pride = {
 	type = character
 
-	modifier_name = "CHILDHOOD_FOCUS_PRIDE"
+	modifier_name = CHILDHOOD_FOCUS_PRIDE
 
 	potential_traits = {
 		haughty
@@ -39,7 +39,7 @@ focus_ch_pride = {
 focus_ch_humility = {
 	type = character
 
-	modifier_name = "CHILDHOOD_FOCUS_HUMILITY"
+	modifier_name = CHILDHOOD_FOCUS_HUMILITY
 
 	potential_traits = {
 		timid
@@ -68,7 +68,7 @@ focus_ch_humility = {
 focus_ch_duty = {
 	type = character
 
-	modifier_name = "CHILDHOOD_FOCUS_DUTY"
+	modifier_name = CHILDHOOD_FOCUS_DUTY
 
 	potential_traits = {
 		conscientious
@@ -96,7 +96,7 @@ focus_ch_duty = {
 focus_ch_etiquette = {
 	type = character
 
-	modifier_name = "CHILDHOOD_FOCUS_ETIQUETTE"
+	modifier_name = CHILDHOOD_FOCUS_ETIQUETTE
 
 	potential_traits = {
 		playful
@@ -125,7 +125,7 @@ focus_ch_etiquette = {
 focus_ch_thrift = {
 	type = character
 
-	modifier_name = "CHILDHOOD_FOCUS_THRIFT"
+	modifier_name = CHILDHOOD_FOCUS_THRIFT
 
 	potential_traits = {
 		curious
@@ -154,7 +154,7 @@ focus_ch_thrift = {
 focus_ch_faith = {
 	type = character
 
-	modifier_name = "CHILDHOOD_FOCUS_FAITH"
+	modifier_name = CHILDHOOD_FOCUS_FAITH
 
 	potential_traits = {
 		idolizer
@@ -176,15 +176,10 @@ focus_ch_faith = {
 	# AI Pick chance
 	chance = {
 		factor = 100
-		modifier = {
-			factor = 0
-			is_ruler = yes
-		}
-		modifier = {
-			factor = 0
-			liege = {
-				religion = ROOT
-			}
+
+		trigger = {
+			is_ruler = no
+			NOT = { religion = liege }
 		}
 	}
 }
@@ -192,7 +187,7 @@ focus_ch_faith = {
 focus_ch_struggle = {
 	type = character
 
-	modifier_name = "CHILDHOOD_FOCUS_STRUGGLE"
+	modifier_name = CHILDHOOD_FOCUS_STRUGGLE
 
 	potential_traits = {
 		rowdy
@@ -215,7 +210,8 @@ focus_ch_struggle = {
 	# AI Pick chance
 	chance = {
 		factor = 100
-		modifier = {
+
+		mult_modifier = {
 			factor = 10
 			liege = {
 				is_nomadic = yes
@@ -227,7 +223,7 @@ focus_ch_struggle = {
 focus_ch_heritage = {
 	type = character
 
-	modifier_name = "CHILDHOOD_FOCUS_HERITAGE"
+	modifier_name = CHILDHOOD_FOCUS_HERITAGE
 
 	potential = {
 		age < 12
@@ -245,15 +241,13 @@ focus_ch_heritage = {
 	# AI Pick chance
 	chance = {
 		factor = 500
-		modifier = {
-			factor = 0
-			is_ruler = yes
-		}
-		modifier = {
-			factor = 0
-			liege = {
-				culture = ROOT
-				religion = ROOT
+
+		trigger = {
+			is_ruler = no
+
+			NOR = {
+				culture = liege
+				religion = liege
 			}
 		}
 	}

--- a/CleanSlate/common/objectives/00_zeus_education_focuses.txt
+++ b/CleanSlate/common/objectives/00_zeus_education_focuses.txt
@@ -10,7 +10,7 @@
 focus_ed_diplomacy = {
 	type = character
 
-	modifier_name = "EDUCATION_FOCUS_DIPLOMACY"
+	modifier_name = EDUCATION_FOCUS_DIPLOMACY
 
 	good_traits = {
 		affectionate
@@ -26,7 +26,7 @@ focus_ed_diplomacy = {
 	diplomacy = 1
 
 	potential = {
-		age = 12
+		age >= 12
 		is_adult = no
 	}
 
@@ -48,7 +48,7 @@ focus_ed_diplomacy = {
 focus_ed_martial = {
 	type = character
 
-	modifier_name = "EDUCATION_FOCUS_MARTIAL"
+	modifier_name = EDUCATION_FOCUS_MARTIAL
 
 	good_traits = {
 		rowdy
@@ -64,7 +64,7 @@ focus_ed_martial = {
 	martial = 1
 
 	potential = {
-		age = 12
+		age >= 12
 		is_adult = no
 	}
 
@@ -80,7 +80,8 @@ focus_ed_martial = {
 	# AI Pick chance
 	chance = {
 		factor = 100
-		modifier = {
+
+		mult_modifier = {
 			factor = 10
 			liege = {
 				is_nomadic = yes
@@ -92,7 +93,7 @@ focus_ed_martial = {
 focus_ed_stewardship = {
 	type = character
 
-	modifier_name = "EDUCATION_FOCUS_STEWARDSHIP"
+	modifier_name = EDUCATION_FOCUS_STEWARDSHIP
 
 	good_traits = {
 		brooding
@@ -108,7 +109,7 @@ focus_ed_stewardship = {
 	stewardship = 1
 
 	potential = {
-		age = 12
+		age >= 12
 		is_adult = no
 	}
 
@@ -130,7 +131,7 @@ focus_ed_stewardship = {
 focus_ed_intrigue = {
 	type = character
 
-	modifier_name = "EDUCATION_FOCUS_INTRIGUE"
+	modifier_name = EDUCATION_FOCUS_INTRIGUE
 
 	good_traits = {
 		playful
@@ -146,7 +147,7 @@ focus_ed_intrigue = {
 	intrigue = 1
 
 	potential = {
-		age = 12
+		age >= 12
 		is_adult = no
 	}
 
@@ -168,7 +169,7 @@ focus_ed_intrigue = {
 focus_ed_learning = {
 	type = character
 
-	modifier_name = "EDUCATION_FOCUS_LEARNING"
+	modifier_name = EDUCATION_FOCUS_LEARNING
 
 	good_traits = {
 		timid
@@ -184,7 +185,7 @@ focus_ed_learning = {
 	learning = 1
 
 	potential = {
-		age = 12
+		age >= 12
 		is_adult = no
 	}
 

--- a/CleanSlate/common/scripted_triggers/00_scripted_triggers_job_minor_titles.txt
+++ b/CleanSlate/common/scripted_triggers/00_scripted_triggers_job_minor_titles.txt
@@ -86,10 +86,11 @@ change_council_job_potential_trigger = {
 
 # ROOT is potential chancellor
 can_be_chancellor_trigger = {
+	independent = no
+	prisoner = no
+	is_incapable = no
+
 	NOR = {
-		independent = yes
-		prisoner = yes
-		is_incapable = yes
 		trait = in_hiding
 		has_character_modifier = resigned_in_anger
 
@@ -104,65 +105,69 @@ can_be_chancellor_trigger = {
 	trigger_if = {
 		limit = { is_adult = yes }
 
-		trigger_if = {
-			limit = { is_female = yes }
+		OR = {
+			trait = horse
 
-			liege = {
-				OR = {
-					has_religion_feature = religion_matriarchal
-					has_religion_feature = religion_equal
-					has_religion_feature = religion_feature_bon
+			trigger_if = {
+				limit = { is_female = yes }
 
-					# Some religions don't mind so much who does what
-					trigger_if = {
-						limit = {
-							OR = {
-								religion = cathar
-								religion = messalian
-							}
-						}
-						religion = ROOT
-					}
+				liege = {
+					OR = {
+						has_religion_feature = religion_matriarchal
+						has_religion_feature = religion_equal
+						has_religion_feature = religion_feature_bon
 
-					# Laws permitting
-					primary_title = {
+						# Some religions don't mind so much who does what
 						trigger_if = {
 							limit = {
 								OR = {
-									has_law = status_of_women_2
-									has_law = status_of_women_3
+									religion = cathar
+									religion = messalian
 								}
 							}
+							religion = ROOT
+						}
 
-							ROOT = {
-								OR = {
-									dynasty = PREVPREV
-									is_close_relative = liege
-									is_married = liege
-									is_consort = liege
-									is_landed = yes
-									trait = nun
+						# Laws permitting
+						primary_title = {
+							trigger_if = {
+								limit = {
+									OR = {
+										has_law = status_of_women_2
+										has_law = status_of_women_3
+									}
+								}
+
+								ROOT = {
+									OR = {
+										dynasty = liege
+										is_close_relative = liege
+										is_married = liege
+										is_consort = liege
+										is_landed = yes
+										trait = nun
+									}
 								}
 							}
+							trigger_else = {
+								has_law = status_of_women_4
+							}
 						}
-						trigger_else = {
-							has_law = status_of_women_4
+
+						# Other conditions under which females can be employed
+						has_game_rule = {
+							name = gender
+							value = all
 						}
-					}
 
-					# Other conditions under which females can be employed
-					has_game_rule = {
-						name = gender
-						value = all
+						trait = horse # So we can have female Glitterhoofs! :D
 					}
-
-					trait = horse # So we can have female Glitterhoofs! :D
 				}
 			}
-		}
-		trigger_else = {
-			liege = {
-				NOT = { has_religion_feature = religion_matriarchal }
+			trigger_else = {
+				liege = {
+					NOT = { has_religion_feature = religion_matriarchal }
+				}
 			}
 		}
 	}
@@ -172,10 +177,11 @@ can_be_chancellor_trigger = {
 }
 
 can_be_marshal_trigger = {
+	independent = no
+	prisoner = no
+	is_incapable = no
+
 	NOR = {
-		independent = yes
-		prisoner = yes
-		is_incapable = yes
 		trait = in_hiding
 		has_character_modifier = resigned_in_anger
 
@@ -190,60 +196,62 @@ can_be_marshal_trigger = {
 	trigger_if = {
 		limit = { is_adult = yes }
 
-		trigger_if = {
-			limit = { is_female = yes }
+		OR = {
+			trait = horse
 
-			liege = {
-				OR = {
-					has_religion_feature = religion_matriarchal
-					has_religion_feature = religion_equal
-					has_religion_feature = religion_feature_bon
+			trigger_if = {
+				limit = { is_female = yes }
 
-					# Some religions don't mind so much who does what
-					trigger_if = {
-						limit = {
-							OR = {
-								religion = cathar
-								religion = messalian
-							}
-						}
-						religion = ROOT
-					}
+				liege = {
+					OR = {
+						has_religion_feature = religion_matriarchal
+						has_religion_feature = religion_equal
+						has_religion_feature = religion_feature_bon
 
-					# Laws permitting
-					primary_title = {
+						# Some religions don't mind so much who does what
 						trigger_if = {
-							limit = { has_law = status_of_women_3 }
-
-							ROOT = {
+							limit = {
 								OR = {
-									dynasty = PREVPREV
-									is_close_relative = liege
-									is_married = liege
-									is_consort = liege
-									is_landed = yes
-									trait = nun
+									religion = cathar
+									religion = messalian
 								}
 							}
+							religion = ROOT
 						}
-						trigger_else = {
-							has_law = status_of_women_4
+
+						# Laws permitting
+						primary_title = {
+							trigger_if = {
+								limit = { has_law = status_of_women_3 }
+
+								ROOT = {
+									OR = {
+										dynasty = liege
+										is_close_relative = liege
+										is_married = liege
+										is_consort = liege
+										is_landed = yes
+										trait = nun
+									}
+								}
+							}
+							trigger_else = {
+								has_law = status_of_women_4
+							}
+						}
+
+						# Other conditions under which females can be employed
+						has_game_rule = {
+							name = gender
+							value = all
 						}
 					}
-
-					# Other conditions under which females can be employed
-					has_game_rule = {
-						name = gender
-						value = all
-					}
-
-					trait = horse # So we can have female Glitterhoofs! :D
 				}
 			}
-		}
-		trigger_else = {
-			liege = {
-				NOT = { has_religion_feature = religion_matriarchal }
+			trigger_else = {
+				liege = {
+					NOT = { has_religion_feature = religion_matriarchal }
+				}
 			}
 		}
 
@@ -258,10 +266,11 @@ can_be_marshal_trigger = {
 }
 
 can_be_treasurer_trigger = {
+	independent = no
+	prisoner = no
+	is_incapable = no
+
 	NOR = {
-		independent = yes
-		prisoner = yes
-		is_incapable = yes
 		trait = in_hiding
 		has_character_modifier = resigned_in_anger
 
@@ -276,65 +285,67 @@ can_be_treasurer_trigger = {
 	trigger_if = {
 		limit = { is_adult = yes }
 
-		trigger_if = {
-			limit = { is_female = yes }
+		OR = {
+			trait = horse
 
-			liege = {
-				OR = {
-					has_religion_feature = religion_matriarchal
-					has_religion_feature = religion_equal
-					has_religion_feature = religion_feature_bon
+			trigger_if = {
+				limit = { is_female = yes }
 
-					# Some religions don't mind so much who does what
-					trigger_if = {
-						limit = {
-							OR = {
-								religion = cathar
-								religion = messalian
-							}
-						}
-						religion = ROOT
-					}
+				liege = {
+					OR = {
+						has_religion_feature = religion_matriarchal
+						has_religion_feature = religion_equal
+						has_religion_feature = religion_feature_bon
 
-					# Laws permitting
-					primary_title = {
+						# Some religions don't mind so much who does what
 						trigger_if = {
 							limit = {
 								OR = {
-									has_law = status_of_women_2
-									has_law = status_of_women_3
+									religion = cathar
+									religion = messalian
 								}
 							}
+							religion = ROOT
+						}
 
-							ROOT = {
-								OR = {
-									dynasty = PREVPREV
-									is_close_relative = liege
-									is_married = liege
-									is_consort = liege
-									is_landed = yes
-									trait = nun
+						# Laws permitting
+						primary_title = {
+							trigger_if = {
+								limit = {
+									OR = {
+										has_law = status_of_women_2
+										has_law = status_of_women_3
+									}
+								}
+
+								ROOT = {
+									OR = {
+										dynasty = liege
+										is_close_relative = liege
+										is_married = liege
+										is_consort = liege
+										is_landed = yes
+										trait = nun
+									}
 								}
 							}
+							trigger_else = {
+								has_law = status_of_women_4
+							}
 						}
-						trigger_else = {
-							has_law = status_of_women_4
+
+						# Other conditions under which females can be employed
+						has_game_rule = {
+							name = gender
+							value = all
 						}
 					}
-
-					# Other conditions under which females can be employed
-					has_game_rule = {
-						name = gender
-						value = all
-					}
-
-					trait = horse # So we can have female Glitterhoofs! :D
 				}
 			}
-		}
-		trigger_else = {
-			liege = {
-				NOT = { has_religion_feature = religion_matriarchal }
+			trigger_else = {
+				liege = {
+					NOT = { has_religion_feature = religion_matriarchal }
+				}
 			}
 		}
 	}
@@ -344,10 +355,11 @@ can_be_treasurer_trigger = {
 }
 
 can_be_spymaster_trigger = {
+	independent = no
+	prisoner = no
+	is_incapable = no
+
 	NOR = {
-		independent = yes
-		prisoner = yes
-		is_incapable = yes
 		trait = in_hiding
 		has_character_modifier = resigned_in_anger
 
@@ -362,84 +374,88 @@ can_be_spymaster_trigger = {
 	trigger_if = {
 		limit = { is_adult = yes }
 
-		trigger_if = {
-			limit = { is_female = yes }
+		OR = {
+			trait = horse
 
-			liege = {
-				OR = {
-					# Special conditions for spymaster position
-					trigger_if = {
-						limit = {
-							OR = {
-								is_married = ROOT
-								is_mother = ROOT
-							}
-						}
-						NOT = { has_religion_feature = religion_patriarchal }
-					}
+			trigger_if = {
+				limit = { is_female = yes }
 
-					has_religion_feature = religion_matriarchal
-					has_religion_feature = religion_equal
-					has_religion_feature = religion_feature_bon
-
-					# Some religions don't mind so much who does what
-					trigger_if = {
-						limit = {
-							OR = {
-								religion = cathar
-								religion = messalian
-							}
-						}
-						religion = ROOT
-					}
-					trigger_else_if = {
-						limit = {
-							religion_group = pagan_group
-							NOT = { has_religion_feature = religion_patriarchal }
-						}
-						ROOT = { religion_group = pagan_group }
-					}
-
-					# Laws permitting
-					primary_title = {
+				liege = {
+					OR = {
+						# Special conditions for spymaster position
 						trigger_if = {
 							limit = {
 								OR = {
-									has_law = status_of_women_1
-									has_law = status_of_women_2
-									has_law = status_of_women_3
+									is_married = ROOT
+									is_mother = ROOT
 								}
 							}
+							NOT = { has_religion_feature = religion_patriarchal }
+						}
 
-							ROOT = {
+						has_religion_feature = religion_matriarchal
+						has_religion_feature = religion_equal
+						has_religion_feature = religion_feature_bon
+
+						# Some religions don't mind so much who does what
+						trigger_if = {
+							limit = {
 								OR = {
-									dynasty = PREVPREV
-									is_close_relative = liege
-									is_married = liege
-									is_consort = liege
-									is_landed = yes
-									trait = nun
+									religion = cathar
+									religion = messalian
 								}
 							}
+							religion = ROOT
 						}
-						trigger_else = {
-							has_law = status_of_women_4
+						trigger_else_if = {
+							limit = {
+								religion_group = pagan_group
+								NOT = { has_religion_feature = religion_patriarchal }
+							}
+							ROOT = { religion_group = pagan_group }
 						}
-					}
 
-					# Other conditions under which females can be employed
-					has_game_rule = {
-						name = gender
-						value = all
-					}
+						# Laws permitting
+						primary_title = {
+							trigger_if = {
+								limit = {
+									OR = {
+										has_law = status_of_women_1
+										has_law = status_of_women_2
+										has_law = status_of_women_3
+									}
+								}
 
-					trait = horse # So we can have female Glitterhoofs! :D
+								ROOT = {
+									OR = {
+										dynasty = liege
+										is_close_relative = liege
+										is_married = liege
+										is_consort = liege
+										is_landed = yes
+										trait = nun
+									}
+								}
+							}
+							trigger_else = {
+								has_law = status_of_women_4
+							}
+						}
+
+						# Other conditions under which females can be employed
+						has_game_rule = {
+							name = gender
+							value = all
+						}
+
+						ROOT = { trait = horse } # So we can have female Glitterhoofs! :D
+					}
 				}
 			}
-		}
-		trigger_else = {
-			liege = {
-				NOT = { has_religion_feature = religion_matriarchal }
+			trigger_else = {
+				liege = {
+					NOT = { has_religion_feature = religion_matriarchal }
+				}
 			}
 		}
 	}
@@ -449,12 +465,12 @@ can_be_spymaster_trigger = {
 }
 
 can_be_spiritual_trigger = {
-	liege = { religion = ROOT }
+	religion = liege
+	independent = no
+	prisoner = no
+	is_incapable = no
 
 	NOR = {
-		independent = yes
-		prisoner = yes
-		is_incapable = yes
 		trait = in_hiding
 		has_character_modifier = resigned_in_anger
 
@@ -499,6 +515,7 @@ can_be_spiritual_trigger = {
 
 	OR = {
 		is_theocracy = yes
+		religion_group = muslim
 
 		trigger_if = {
 			limit = {
@@ -506,8 +523,6 @@ can_be_spiritual_trigger = {
 			}
 			is_ruler = no
 		}
-
-		liege = { religion_group = muslim }
 
 		trigger_if = {
 			limit = { clan = yes }
@@ -531,14 +546,16 @@ can_be_spiritual_trigger = {
 
 	trigger_if = {
 		limit = {
-			liege = { religion_group = muslim }
+			religion_group = muslim
 		}
 
-		trait = detached_priest
-		trait = martial_cleric
-		trait = scholarly_theologian
-		trait = mastermind_theologian
-		has_character_flag = special_spiritual
+		OR = {
+			trait = detached_priest
+			trait = martial_cleric
+			trait = scholarly_theologian
+			trait = mastermind_theologian
+			has_character_flag = special_spiritual
+		}
 	}
 }
 


### PR DESCRIPTION
All plots, ambitions, focuses and factions now use 'trigger'-clauses instead of modifiers with factor 0.
Bugfix: AI now properly consider dynasty of potential targets of kill plots
Bugfix: Plots and factions now only check for crown authority if Conclave is disabled
Bugfix: Claimant factions now properly check for religion features and gender succession law depending on gender
Bugfix: Factions now check for 'horde_culture', instead of 'tribal_type_title', which hasn't been used since late 2014, when tribal government was added
Somehow, a fix for 'Become chancellor'-ambitions, small optimisations