### PR TITLE
Fixed broken loc

### DIFF
--- a/CleanSlate/events/LT_wonder_flavor_events.txt
+++ b/CleanSlate/events/LT_wonder_flavor_events.txt
@@ -3035,7 +3035,7 @@ character_event = { #Lovers make love
 	is_triggered_only = yes
 
 	option = {  # ok
-		name = EVTOPTA_LT_20432
+		name = EVTOPTA_LT_20432_B # life is good
 		random = {
 			chance = 30
 			opinion = { modifier = opinion_budding_romance who = FROM }


### PR DESCRIPTION
This is very minor.

> --- Error 1 of 1 ---
> At <mod>\events\LT_wonder_flavor_events.txt [character_event\option\name] (Line 3038, column 3):
> "EVTOPTA_LT_20432" is not a valid Key or NamingInfo.

There are `EVTOPTA_LT_20432_A` and `EVTOPTA_LT_20432_B`, there's no `EVTOPTA_LT_20432`.