### PR TITLE
Fix wrong government with holy order

### DIFF
--- a/CleanSlate/common/governments/theocracy_governments.txt
+++ b/CleanSlate/common/governments/theocracy_governments.txt
@@ -30,6 +30,7 @@ theocracy_governments = {
 		color = { 220 220 220 }
 
 		potential = {
+			holy_order = no
 			NOT = {	is_government_potential = muslim_government }
 
 			trigger_if = {

--- a/CleanSlate/common/governments/tribal_governments.txt
+++ b/CleanSlate/common/governments/tribal_governments.txt
@@ -35,6 +35,7 @@ tribal_governments = {
 		color = { 92 31 23 }
 
 		potential = {
+			holy_order = no
 			trigger_if = {
 				limit = { has_game_started = yes }
 				is_feudal = no


### PR DESCRIPTION
If the capital holding is not a castle, things will go funny.
Teutonic order can have this bug in 1204/1220 bm and more.
They become tribal/theocracy for holding tribe/temple as the capital.
Literally, a mercenary title would confront the same bug.
But there's no historical mercenary character on map so I just leave it.
(theocratic mercenary sounds stronk.)