### PR TITLE
Revert using is_offmap_governor in a trigger

### DIFF
--- a/CleanSlate/events/jd_chinese_war_events.txt
+++ b/CleanSlate/events/jd_chinese_war_events.txt
@@ -13,7 +13,11 @@ character_event = {
 
 	trigger = {
 		# China is the aggressor
-		FROM = { is_offmap_governor = offmap_china }
+		offmap_china = {
+			governor = {
+				character = FROM
+			}
+		}
 	}
 
 	immediate = {
@@ -46,7 +50,11 @@ character_event = {
 
 	trigger = {
 		# China is the defender
-		is_offmap_governor = offmap_china
+		offmap_china = {
+			governor = {
+				character = ROOT
+			}
+		}
 	}
 
 	immediate = {


### PR DESCRIPTION
**Summary**
Revert using is_offmap_governor in a trigger in d972ade

**Purpose of change**
`is_offmap_governor = offmap_china` also return true for my other governors of custom offmap_powers (e.g offmap_hre/offmap_mexikha)

**Describe the solution**
The vanilla old style scope just works fine.

**Testing**
Tested in a beta version of my [Sacrum Imperium Romanum](https://steamcommunity.com/sharedfiles/filedetails/?id=2442792154) and [Jade Serpent](https://steamcommunity.com/sharedfiles/filedetails/?id=1871385339) mod