### PR TITLE
events: fix a possible typo

### DIFF
--- a/CleanSlate/events/HFP_crusade_events.txt
+++ b/CleanSlate/events/HFP_crusade_events.txt
@@ -1012,7 +1012,7 @@ character_event = {
 	trigger = {
 		OR = {
 			has_pledged_crusade_participation = yes
-			crusade_preparation_strength < 175
+			crusade_preparation_strength < 1.75
 		}
 	}
 


### PR DESCRIPTION
smaller than 17500% almost equals to no upper limit,
which is meaningless. This will keep participants joining the crusade nearly endlessly.