### PR TITLE
e_turan is now valid for manifest_destiny_invasion

### DIFF
--- a/CleanSlate/common/cb_types/adventurer_cbs.txt
+++ b/CleanSlate/common/cb_types/adventurer_cbs.txt
@@ -641,6 +641,7 @@ manifest_destiny_invasion = {
 	can_use_title = {
 		empire = {
 			OR = {
+				title = e_turan
 				title = e_persia
 				title = e_byzantium
 				title = e_arabia


### PR DESCRIPTION
e_turan was added patch 3.0, and k_transoxiana redistributed into e_turan
Making Timurids never invade their historical core after Holy Fury
Also making Seljuks less likely go expansion eastward