### PR TITLE
fix TOG.1212: thirdparty_title accepts a title or a scope chain

### DIFF
--- a/CleanSlate/events/oldgods_adventures.txt
+++ b/CleanSlate/events/oldgods_adventures.txt
@@ -1007,7 +1007,7 @@ character_event = {
 					}
 				}
 
-				save_event_target_as = adventurer_target_province
+				county = { save_event_target_as = adventurer_target_title }
 			}
 		}
 
@@ -1058,7 +1058,7 @@ character_event = {
 		unsafe_war = {
 			target = event_target:adventurer_target
 			casus_belli = duchy_adventure
-			thirdparty_title = event_target:adventurer_target_province
+			thirdparty_title = event_target:adventurer_target_title
 			tier = DUKE
 		}
 


### PR DESCRIPTION
fix #75
thirdparty_title accepts a title or a scope chain, while adventurer_target_province is pointing to a province.
(but it's OK if PREV scopes to a province, interesting)