### PR TITLE
law: fix wrong scope for "is_patrician"

### DIFF
--- a/CleanSlate/common/laws/succession_laws.txt
+++ b/CleanSlate/common/laws/succession_laws.txt
@@ -395,7 +395,9 @@ succession_laws = {
 					NOR = {
 						has_dlc = "Conclave"
 						has_law = succ_hre_elective
-						is_patrician = yes
+						holder_scope = {
+							is_patrician = yes
+						}
 					}
 
 					has_crown_law_title = yes

--- a/CleanSlate/common/scripted_triggers/00_government_triggers.txt
+++ b/CleanSlate/common/scripted_triggers/00_government_triggers.txt
@@ -172,18 +172,22 @@ merchant_republic_government_potential_trigger = {
 		AND = {
 			is_patrician = yes
 
-			# Liege must be MR
-			liege_before_war = {
-				is_merchant_republic = yes
+			OR = {
+				# Liege must be MR
+				liege_before_war = {
+					is_merchant_republic = yes
 
-				# MR can't be under MR
-				trigger_if = {
-					limit = { independent = no }
+					# MR can't be under MR
+					trigger_if = {
+						limit = { independent = no }
 
-					liege_before_war = {
-						is_merchant_republic = no
+						liege_before_war = {
+							is_merchant_republic = no
+						}
 					}
 				}
+
+				has_game_started = no
 			}
 		}
 	}


### PR DESCRIPTION
Fix #95 

government: patricians should stay in merchant_republic_government
even with holding other baron tier titles

laws:
A minor bad scope mistake,
and if the Conclave DLC is disabled, it blocks patricians from seniority succession
