### PR TITLE
Bugfix: reformed god name mess

### DIFF
--- a/CleanSlate/common/on_actions/00_on_actions.txt
+++ b/CleanSlate/common/on_actions/00_on_actions.txt
@@ -2,6 +2,7 @@
 on_startup = {
 	effect = {
 		setup_province_pulse = yes
+		setup_reformed_religion_scope = yes
 		setup_holy_order_religion_scopes = yes
 	}
 

--- a/CleanSlate/common/scripted_effects/00_religion_effects.txt
+++ b/CleanSlate/common/scripted_effects/00_religion_effects.txt
@@ -1988,13 +1988,280 @@ apply_dogmatic_on_start_effect = {
 	remove_intermarry = jewish_group
 }
 
-# Reforming religion with certain Doctrines might result in gods being added/removed/changed
-reformation_god_names_changes_effect = {
-	ROOT = { # Reformer
+# Fires on_startup
+setup_reformed_religion_scope = {
+	if = {
+		limit = {
+			is_multiplayer_host_character = yes
+		}
+
+		aztec_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:aztec_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:aztec_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_aztec_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		baltic_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:baltic_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:baltic_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_baltic_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		bon_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:bon_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:bon_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_bon_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		finnish_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:finnish_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:finnish_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_finnish_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		hellenic_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:hellenic_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:hellenic_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = k_hellenic_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		norse_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:norse_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:norse_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_norse_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		slavic_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:slavic_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:slavic_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_slavic_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		tengri_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:tengri_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:tengri_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_tengri_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+		
+		west_african_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:west_african_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:west_african_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_west_african_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		zun_pagan_reformed = {
+			if = {
+				limit = {
+					event_target:zun_pagan_reformed_override = {
+						always = yes
+					}
+				}
+				save_persistent_event_target = {
+					name = religion_title
+					scope = event_target:zun_pagan_reformed_override
+				}
+			}
+			else = {
+				save_persistent_event_target = {
+					name = religion_title
+					scope = d_zun_pagan_reformed
+				}
+			}
+			persistent_event_target:religion_title = {
+				save_persistent_event_target = {
+					name = religion_scope
+					scope = PREV
+				}
+			}
+		}
+
+		# scan all reformed religion
 		if = {
 			limit = {
-				has_dlc = "Holy Fury"
+				is_save_game = yes
+				has_religion_features = yes
 
+				# Do not support Random Start
 				NOT = {
 					has_alternate_start_parameter = {
 						key = religion_names
@@ -2003,614 +2270,208 @@ reformation_god_names_changes_effect = {
 				}
 			}
 
-			if = { # A ruler reforms Norse Paganism
-				limit = {
-					religion = norse_pagan_reformed
-
-					OR = {
-						has_religion_feature = religion_matriarchal
-						has_religion_feature = religion_patriarchal
-						has_religion_feature = religion_dogmatic
-					}
-				}
-
-				remove_god_names = yes
-				remove_evil_god_names = yes
-
-				if = { # Religion is Patriarchal
-					limit = { has_religion_feature = religion_patriarchal }
-
-					set_high_god_name = GOD_ODIN
-					add_god_name = GOD_ODIN_2
-
-					if = {
-						limit = {
-							NOT = { has_religion_feature = religion_dogmatic }
+			aztec_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
 						}
-
-						add_god_name = GOD_THOR
-						add_god_name = GOD_THE_THUNDERER
-						add_god_name = GOD_THE_ALLFATHER
-						add_god_name = GOD_TYR
 					}
-
-					add_evil_god_name = GOD_FRIGG
-					add_evil_god_name = HEL
-					add_evil_god_name = GOD_SIF
-					add_evil_god_name = GOD_SKADI
 				}
-
-				else_if = { # Religion is Matriarchal
-					limit = { has_religion_feature = religion_matriarchal }
-					set_high_god_name = GOD_FRIGG
-					add_god_name = GOD_FRIGG_2
-
-					if = {
-						limit = {
-							NOT = { has_religion_feature = religion_dogmatic }
-						}
-
-						add_god_name = GOD_SIF
-						add_god_name = GOD_THE_ALLMOTHER
-						add_god_name = GOD_SKADI
-						add_god_name = GOD_FREY
-					}
-
-					add_evil_god_name = LOKI
-					add_evil_god_name = GOD_THE_THUNDERER
-					add_evil_god_name = FENRIR
-					add_evil_god_name = JORMUNGANDR
-				}
-
-				else = { # Religion is not sexist, add just Dogmatic set
-					set_high_god_name = GOD_THE_ALLFATHER
-					add_god_name = GOD_THE_ALLFATHER_2
-					add_evil_god_name = LOKI
-					add_evil_god_name = HEL
-					add_evil_god_name = FENRIR
-					add_evil_god_name = JORMUNGANDR
+				parent_religion = {
+					rebuild_god_name_effect = yes
 				}
 			}
-
-			else_if = { # A ruler reforms Tengri Paganism
-				limit = {
-					religion = tengri_pagan_reformed
-
-					OR = {
-						has_religion_feature = religion_matriarchal
-						has_religion_feature = religion_patriarchal
-						has_religion_feature = religion_dogmatic
+			baltic_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
+						}
 					}
 				}
-
-				remove_god_names = yes
-				remove_evil_god_names = yes
-
-				if = { # Religion is Patriarchal
-					limit = { has_religion_feature = religion_patriarchal }
-
-					set_high_god_name = GOD_TENGRI
-					add_god_name = GOD_TENGRI_2
-					add_god_name = GOD_TUNG-AK
-					add_evil_god_name = GOD_AK_ANA
-					add_evil_god_name = KOMUR_HAN
-				}
-
-				else_if = { # Religion is Matriarchal
-					limit = { has_religion_feature = religion_matriarchal }
-
-					set_high_god_name = GOD_UMAY
-					add_god_name = GOD_UMAY_2
-					add_god_name = GOD_AK_ANA
-					add_god_name = GOD_KUBAI
-					add_evil_god_name = ERLIK
-					add_evil_god_name = KOMUR_HAN
-				}
-
-				else = { # Religion is not sexist, add just Dogmatic set
-					set_high_god_name = GOD_TENGRI
-					add_god_name = GOD_TENGRI_2
-					add_evil_god_name = ERLIK
-					add_evil_god_name = KOMUR_HAN
+				parent_religion = {
+					rebuild_god_name_effect = yes
 				}
 			}
-
-			else_if = { # A ruler reforms Baltic Paganism
-				limit = {
-					religion = baltic_pagan_reformed
-
-					OR = {
-						has_religion_feature = religion_matriarchal
-						has_religion_feature = religion_patriarchal
-						has_religion_feature = religion_dogmatic
+			bon_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
+						}
 					}
 				}
-
-				remove_god_names = yes
-				remove_evil_god_names = yes
-
-				if = { # Religion is Patriarchal
-					limit = { has_religion_feature = religion_patriarchal }
-
-					set_high_god_name = GOD_DIEVAS
-					add_god_name = GOD_DIEVAS_2
-					add_god_name = GOD_PERKUNAS
-					add_evil_god_name = GOD_LAIMA
-				}
-
-				else_if = { # Religion is Matriarchal
-					limit = { has_religion_feature = religion_matriarchal }
-
-					set_high_god_name = GOD_GABIJA
-					add_god_name = GOD_GABIJA_2
-					add_god_name = GOD_LAIMA
-					add_evil_god_name = VELNIAS
-				}
-
-				else = { # Religion is not sexist, add just Dogmatic set
-					set_high_god_name = GOD_DIEVAS
-					add_god_name = GOD_DIEVAS_2
-					add_evil_god_name = VELNIAS
+				parent_religion = {
+					rebuild_god_name_effect = yes
 				}
 			}
-
-			else_if = { # A ruler reforms Finnish Paganism
-				limit = {
-					religion = finnish_pagan_reformed
-
-					OR = {
-						has_religion_feature = religion_matriarchal
-						has_religion_feature = religion_patriarchal
-						has_religion_feature = religion_dogmatic
-					}
-				}
-
-				remove_god_names = yes
-				remove_evil_god_names = yes
-
-				if = { # Religion is Patriarchal
-					limit = { has_religion_feature = religion_patriarchal }
-
-					set_high_god_name = GOD_UKKO
-					add_god_name = GOD_UKKO_2
-
-					if = {
-						limit = {
-							NOT = { has_religion_feature = religion_dogmatic }
+			finnish_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
 						}
-
-						add_god_name = GOD_PERKELE
-						add_god_name = GOD_JUMI
-						add_god_name = GOD_THE_GREAT_BEAR
-						add_god_name = GOD_TAPIO
-						add_god_name = GOD_TAARA
-						add_god_name = GOD_OMOL
 					}
-
-					add_evil_god_name = GOD_MASTOR_AVA
-					add_evil_god_name = GOD_KALMA
 				}
-
-				else_if = { # Religion is Matriarchal
-					limit = { has_religion_feature = religion_matriarchal }
-
-					set_high_god_name = GOD_KUU
-					add_god_name = GOD_KUU_2
-
-					if = {
-						limit = {
-							NOT = { has_religion_feature = religion_dogmatic }
-						}
-
-						add_god_name = GOD_MASTOR_AVA
-						add_god_name = GOD_KALMA
-						add_god_name = GOD_THE_GREAT_BEAR
-					}
-
-					add_evil_god_name = TUONI
-					add_evil_god_name = TUONETAR
-				}
-
-				else = { # Religion is not sexist, add just Dogmatic set
-					set_high_god_name = GOD_UKKO
-					add_god_name = GOD_UKKO_2
-					add_evil_god_name = TUONI
+				parent_religion = {
+					rebuild_god_name_effect = yes
 				}
 			}
-
-			else_if = { # A ruler reforms Aztec Paganism
-				limit = {
-					religion = aztec_pagan_reformed
-
-					OR = {
-						has_religion_feature = religion_matriarchal
-						has_religion_feature = religion_patriarchal
-						has_religion_feature = religion_dogmatic
-						has_religion_feature = religion_proselytizing
+			hellenic_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
+						}
 					}
 				}
-
-				remove_god_names = yes
-				remove_evil_god_names = yes
-
-				if = { # Religion is Patriarchal
-					limit = { has_religion_feature = religion_patriarchal }
-
-					set_high_god_name = GOD_HUITZILOPOCHTLI
-					add_god_name = GOD_HUITZILOPOCHTLI_2
-					add_god_name = GOD_XIPE_TOTEC
-					add_god_name = GOD_TEZCATLIPOCA
-					add_god_name = GOD_QUETZALCOATL
-					add_god_name = GOD_TLALOC
-					add_evil_god_name = TLAZOLTEOTL
-					add_evil_god_name = GOD_MICTLANTECUHTLI
-					add_evil_god_name = XOLOTL
-				}
-
-				else_if = { # Religion is Matriarchal
-					limit = { has_religion_feature = religion_matriarchal }
-
-					set_high_god_name = GOD_CIHUACOATL
-					add_god_name = GOD_CIHUACOATL_2
-					add_god_name = GOD_MALINALXOCHITL
-					add_god_name = GOD_METZTLI
-					add_god_name = GOD_TONACACIHUATL
-					add_evil_god_name = TLAZOLTEOTL
-					add_evil_god_name = GOD_MICTLANTECUHTLI
-					add_evil_god_name = XOLOTL
-				}
-
-				else = { # Religion is not sexist
-					if = { # add just Proselytizing set
-						limit = { has_religion_feature = religion_proselytizing }
-
-						set_high_god_name = GOD_QUETZALCOATL
-						add_god_name = GOD_QUETZALCOATL_2
-						add_evil_god_name = GOD_TEZCATLIPOCA
-					}
-					else_if = { # add just Dogmatic set
-						limit = { has_religion_feature = religion_dogmatic 	}
-
-						set_high_god_name = GOD_HUITZILOPOCHTLI
-						add_god_name = GOD_HUITZILOPOCHTLI_2
-						add_evil_god_name = TLAZOLTEOTL
-					}
+				parent_religion = {
+					rebuild_god_name_effect = yes
 				}
 			}
-
-			else_if = { # A ruler reforms Slavic Paganism
-				limit = {
-					religion = slavic_pagan_reformed
-
-					OR = {
-						has_religion_feature = religion_matriarchal
-						has_religion_feature = religion_patriarchal
-						has_religion_feature = religion_dogmatic
-					}
-				}
-
-				remove_god_names = yes
-				remove_evil_god_names = yes
-
-				if = { # Religion is Patriarchal
-					limit = { has_religion_feature = religion_patriarchal }
-
-					set_high_god_name = GOD_PERUN
-					add_god_name = GOD_PERUN_2
-
-					if = {
-						limit = {
-							NOT = { has_religion_feature = religion_dogmatic }
+			norse_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
 						}
-
-						add_god_name = GOD_JARILO
-						add_god_name = GOD_SVAROG
-						add_god_name = GOD_TRIGLAV
-						add_god_name = GOD_RADEGAST
 					}
-
-					add_evil_god_name = GOD_VELES
-					add_evil_god_name = GOD_MEDEINA
 				}
-
-				else_if = { # Religion is Matriarchal
-					limit = { has_religion_feature = religion_matriarchal }
-
-					set_high_god_name = GOD_MEDEINA
-					add_god_name = GOD_MEDEINA_2
-
-					if = {
-						limit = {
-							NOT = { has_religion_feature = religion_dogmatic }
-						}
-
-						add_god_name = GOD_DODOLA
-						add_god_name = GOD_KOSTROMA
-						add_god_name = GOD_MARZANNA
-					}
-
-					add_evil_god_name = GOD_VELES
-					add_evil_god_name = CHERNOBOG
-				}
-
-				else = { # Religion is not sexist, add just Dogmatic set
-					set_high_god_name = GOD_PERUN
-					add_god_name = GOD_PERUN_2
-					add_evil_god_name = GOD_VELES
-					add_evil_god_name = CHERNOBOG
+				parent_religion = {
+					rebuild_god_name_effect = yes
 				}
 			}
-
-			else_if = { # A ruler reforms African Paganism
-				limit = {
-					religion = west_african_pagan_reformed
-					has_religion_feature = religion_matriarchal
+			slavic_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
+						}
+					}
 				}
-				set_high_god_name = GOD_THE_MOTHER
+				parent_religion = {
+					rebuild_god_name_effect = yes
+				}
 			}
-
-			else_if = { # A ruler reforms Bon Paganism
-				limit = {
-					religion = bon_pagan_reformed
-					has_religion_feature = religion_dogmatic
+			tengri_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
+						}
+					}
 				}
-
-				remove_god_names = yes
-				set_high_god_name = GOD_SANGPO_BUMTRI
-				add_god_name = GOD_SANGPO_BUMTRI_2
-				add_evil_god_name = GOD_THE_EVIL_ONES
+				parent_religion = {
+					rebuild_god_name_effect = yes
+				}
 			}
-
-			else_if = { # A ruler reforms Hellenism
-				limit = { religion = hellenic_pagan_reformed }
-
-				if = { # while being Greek-cultured: change all the gods to their Greek names
-					limit = { culture = greek }
-
-					remove_god_names = yes
-					remove_evil_god_names = yes
-					set_global_flag = flag_hellenic_greek_reformation # Handles other instances
-
-					if = { # Religion is Patriarchal
-						limit = { has_religion_feature = religion_patriarchal }
-
-						if = { # Poseidon finally gets his due
-							limit = { has_religion_feature = religion_seafaring }
-							set_high_god_name = GOD_POSEIDON
+			zun_pagan = {
+				if = {
+					limit = {
+						parent_religion = {
+							always = yes
 						}
-						else = {
-							set_high_god_name = GOD_GREEK_JUPITER # Otherwise shows Conclave...
-						}
-
-						if = { # Dogmatics only get one
-							limit = {
-								NOT = { has_religion_feature = religion_dogmatic }
-							}
-
-							add_god_name = GOD_GREEK_JUPITER_2 # Otherwise shows Conclave...
-							add_god_name = GOD_POSEIDON_2
-							add_god_name = GOD_HADES
-							add_god_name = GOD_ARES
-							add_god_name = GOD_HEPHAESTUS
-							add_god_name = GOD_APOLLO
-						}
-
-						add_evil_god_name = GOD_APHRODITE
-						add_evil_god_name = GOD_HERA
-						add_evil_god_name = GOD_ATHENA
-						add_evil_god_name = GOD_ARTEMIS
-						add_evil_god_name = GOD_DELFINE
-					}
-
-					else_if = { # Religion is Matriarchal
-						limit = { has_religion_feature = religion_matriarchal }
-
-						set_high_god_name = GOD_HERA
-						add_god_name = GOD_HERA_2
-
-						if = { # Dogmatics only get one
-							limit = {
-								NOT = { has_religion_feature = religion_dogmatic }
-							}
-
-							add_god_name = GOD_DEMETRA
-							add_god_name = GOD_ATHENA
-							add_god_name = GOD_APHRODITE
-							add_god_name = GOD_ARTEMIS
-							add_god_name = GOD_HESTIA
-						}
-
-						add_evil_god_name = GOD_HADES
-						add_evil_god_name = GOD_GREEK_JUPITER # Otherwise shows Conclave...
-						add_evil_god_name = GOD_POSEIDON
-						add_evil_god_name = GOD_ARES
-						add_evil_god_name = GOD_TYPHON
-					}
-
-					else = { # Religion is not sexist, re-add all the gods
-						if = { # Poseidon finally gets his due
-							limit = { has_religion_feature = religion_seafaring }
-							set_high_god_name = GOD_POSEIDON
-						}
-						else = {
-							set_high_god_name = GOD_GREEK_JUPITER # Otherwise shows Conclave...
-						}
-
-						if = { # Dogmatics only get one
-							limit = {
-								NOT = { has_religion_feature = religion_dogmatic }
-							}
-
-							add_god_name = GOD_GREEK_JUPITER_2 # Otherwise shows Conclave...
-							add_god_name = GOD_POSEIDON_2
-							add_god_name = GOD_HADES
-							add_god_name = GOD_HERA
-							add_god_name = GOD_DEMETRA
-							add_god_name = GOD_ATHENA
-							add_god_name = GOD_ARES
-							add_god_name = GOD_HEPHAESTUS
-							add_god_name = GOD_APHRODITE
-							add_god_name = GOD_APOLLO
-							add_god_name = GOD_ARTEMIS
-							add_god_name = GOD_HESTIA
-						}
-
-						add_evil_god_name = GOD_HADES
-						add_evil_god_name = GOD_KRONOS
-						add_evil_god_name = GOD_DIONYSUS
-						add_evil_god_name = GOD_HERMES
-						add_evil_god_name = GOD_TYPHON
 					}
 				}
+				parent_religion = {
+					rebuild_god_name_effect = yes
+				}
+			}
+		}
+	}
+}
 
-				else = { # while NOT being Greek-cultured
-					remove_god_names = yes
-					remove_evil_god_names = yes
+export_reformer_to_title_effect = {
+	# THIS is the religion title
+	# PREV is the religion_scope
+	if = {
+		limit = {
+			has_dlc = "Holy Fury"
 
-					if = { # Religion is Patriarchal
-						limit = { has_religion_feature = religion_patriarchal }
-
-						if = { # Poseidon finally gets his due
-							limit = { has_religion_feature = religion_seafaring }
-							set_high_god_name = GOD_NEPTUNE
-						}
-
-						else = {
-							set_high_god_name = GOD_JUPITER
-						}
-
-						if = { # Dogmatics only get one
-							limit = {
-								NOT = { has_religion_feature = religion_dogmatic }
-							}
-
-							add_god_name = GOD_JUPITER_2
-							add_god_name = GOD_NEPTUNE_2
-							add_god_name = GOD_PLUTO
-							add_god_name = GOD_MARS
-							add_god_name = GOD_VULCAN
-							add_god_name = GOD_APOLLO
-						}
-
-						add_evil_god_name = GOD_VENUS
-						add_evil_god_name = GOD_JUNO
-						add_evil_god_name = GOD_MINERVA
-						add_evil_god_name = GOD_DIANA
-						add_evil_god_name = GOD_DELFINE
-					}
-
-					else_if = { # Religion is Matriarchal
-						limit = { has_religion_feature = religion_matriarchal }
-
-						set_high_god_name = GOD_JUNO
-						add_god_name = GOD_JUNO_2
-
-						if = { # Dogmatics only get one
-							limit = {
-								NOT = { has_religion_feature = religion_dogmatic }
-							}
-
-							add_god_name = GOD_CERES
-							add_god_name = GOD_MINERVA
-							add_god_name = GOD_VENUS
-							add_god_name = GOD_DIANA
-							add_god_name = GOD_VESTA
-						}
-
-						add_evil_god_name = GOD_PLUTO
-						add_evil_god_name = GOD_JUPITER
-						add_evil_god_name = GOD_NEPTUNE
-						add_evil_god_name = GOD_MARS
-						add_evil_god_name = GOD_TYPHON
-					}
-
-					else = { # Religion is not sexist, re-add all the gods
-						if = { # Poseidon finally gets his due
-							limit = { has_religion_feature = religion_seafaring }
-							set_high_god_name = GOD_NEPTUNE
-						}
-						else = {
-							set_high_god_name = GOD_JUPITER
-						}
-
-						if = { # Dogmatics only get one
-							limit = {
-								NOT = { has_religion_feature = religion_dogmatic }
-							}
-
-							add_god_name = GOD_JUPITER_2
-							add_god_name = GOD_NEPTUNE_2
-							add_god_name = GOD_PLUTO
-							add_god_name = GOD_JUNO
-							add_god_name = GOD_CERES
-							add_god_name = GOD_MINERVA
-							add_god_name = GOD_MARS
-							add_god_name = GOD_VULCAN
-							add_god_name = GOD_VENUS
-							add_god_name = GOD_APOLLO
-							add_god_name = GOD_DIANA
-							add_god_name = GOD_VESTA
-						}
-
-						add_evil_god_name = GOD_SATURN
-						add_evil_god_name = GOD_PLUTO
-						add_evil_god_name = GOD_BACCHUS
-						add_evil_god_name = GOD_MERCURY
-						add_evil_god_name = GOD_TYPHON
-					}
+			NOT = {
+				has_alternate_start_parameter = {
+					key = religion_names
+					value = random
 				}
 			}
 		}
 
+		save_event_target_as = religion_title_for_setup
+
 		if = {
-			limit = { # Holy Family actually becomes Holy
-				OR = {
-					has_religion_feature = religion_holy_family
-					has_religion_feature = religion_feature_zun
+			limit = {
+				PREV = { religion = hellenic_pagan_reformed }
+			}
+
+			if = { # while being Greek-cultured: change all the gods to their Greek names
+				limit = {
+					ROOT = { culture = greek }
+				}
+
+				PREV = {
+					set_flag = greek_reformation
 				}
 			}
 
-			if = {
-				limit = { # Reformer himself, but only if he is not becoming the High God due to synergy
-					NOT = { has_religion_feature = religion_temporal_head }
-
-					trigger_if = {
-						limit = { is_female = no }
-						NOT = { has_religion_feature = religion_matriarchal }
-					}
-					trigger_else = {
-						NOT = { has_religion_feature = religion_patriarchal }
-					}
+			else = {
+				PREV = {
+					set_flag = latin_reformation
 				}
-
-				add_god_name = string_reformer_god
 			}
+		}
 
+		save_persistent_event_target = {
+			name = god_self
+			scope = ROOT
+		}
+
+		ROOT = {
 			if = { # Spouse
-				limit = { is_married = yes }
-
-				random_spouse = { save_event_target_as = scoped_god_spouse }
-
-				if = {
-					limit = {
+				limit = {
+					any_spouse = {
 						trigger_if = {
-							limit = { is_female = yes }
-							NOT = { has_religion_feature = religion_matriarchal }
+							limit = { is_female = no }
+
+							ROOT = {
+								NOT = { has_religion_feature = religion_matriarchal }
+							}
 						}
 						trigger_else = {
-							NOT = { has_religion_feature = religion_patriarchal }
+							ROOT = {
+								NOT = { has_religion_feature = religion_patriarchal }
+							}
+						}
+					}
+				}
+
+				random_spouse = {
+					limit = {
+						trigger_if = {
+							limit = { is_female = no }
+
+							ROOT = {
+								NOT = { has_religion_feature = religion_matriarchal }
+							}
+						}
+						trigger_else = {
+							ROOT = {
+								NOT = { has_religion_feature = religion_patriarchal }
+							}
 						}
 					}
 
-					add_god_name = string_reformer_spouse_god
-				}
-				else = {
-					add_evil_god_name = string_reformer_spouse_god
+					event_target:religion_title_for_setup = {
+						save_persistent_event_target = {
+							name = god_spouse
+							scope = PREV
+						}
+					}
 				}
 			}
 
-			if = {
-				limit = { # Child
+			if = { # Child
+				limit = {
 					any_child = {
 						trigger_if = {
 							limit = { is_female = no }
@@ -2647,14 +2508,17 @@ reformation_god_names_changes_effect = {
 						is_primary_heir = ROOT
 					}
 
-					save_event_target_as = scoped_god_child
+					event_target:religion_title_for_setup = {
+						save_persistent_event_target = {
+							name = god_child
+							scope = PREV
+						}
+					}
 				}
-
-				add_god_name = string_reformer_child_god
 			}
 
-			if = {
-				limit = { # Sibling
+			if = { # Sibling
+				limit = {
 					any_sibling = {
 						trigger_if = {
 							limit = { is_female = no }
@@ -2691,24 +2555,653 @@ reformation_god_names_changes_effect = {
 						is_primary_heir = ROOT
 					}
 
-					save_event_target_as = scoped_god_sibling
+					event_target:religion_title_for_setup = {
+						save_persistent_event_target = {
+							name = god_sibling
+							scope = PREV
+						}
+					}
 				}
+			}
+		}
+	}
+}
 
-				add_god_name = string_reformer_sibling_god
+rebuild_god_name_effect = {
+	# THIS is the religion_scope
+	if = {
+		limit = {
+			OR = {
+				trigger_if = {
+					limit = { has_religion_feature = religion_patriarchal }
+					NOR = { # There is no matching composition in vanilla
+						religion = west_african_pagan_reformed
+						religion = zun_pagan_reformed
+					}
+				}
+				trigger_if = {
+					limit = { has_religion_feature = religion_matriarchal }
+					NOR = {
+						religion = west_african_pagan_reformed
+						religion = zun_pagan_reformed
+					}
+				}
+				trigger_if = {
+					limit = { has_religion_feature = religion_dogmatic }
+					NOR = {
+						religion = west_african_pagan_reformed
+						religion = zun_pagan_reformed
+					}
+				}
+				trigger_if = {
+					limit = { has_religion_feature = religion_proselytizing }
+					religion = aztec_pagan_reformed
+				}
+				has_religion_feature = religion_holy_family
+				has_religion_feature = religion_feature_zun
+			}
+
+			NOT = {
+				has_alternate_start_parameter = {
+					key = religion_names
+					value = random
+				}
 			}
 		}
 
+		persistent_event_target:religion_title = {
+			log = "====================DEBUG===================="
+			log = "[Prev.GetName] fired rebuild_god_name_effect"
+			log = "Reformer - [This.god_self.GetTitledName]"
+			log = "============================================="
+		}
+		save_event_target_as = religion_target
+
+		# Formatting god namespace
+		remove_god_names = yes
+		remove_evil_god_names = yes
+
 		if = {
-			limit = { # Reformer becomes the High God
+			limit = { # Holy Family actually becomes Holy
 				OR = {
 					has_religion_feature = religion_holy_family
 					has_religion_feature = religion_feature_zun
 				}
-
-				has_religion_feature = religion_temporal_head
 			}
 
-			set_high_god_name = string_reformer_god
+			# Runs in religion title scope, for persistent_event_target stored inside
+			persistent_event_target:religion_title = {
+				if = {
+					limit = { # Reformer himself, but only if he is not becoming the High God due to synergy
+						NOT = { has_religion_feature = religion_temporal_head }
+
+						trigger_if = {
+							limit = {
+								persistent_event_target:god_self = { is_female = no }
+							}
+
+							NOT = { has_religion_feature = religion_matriarchal }
+						}
+						trigger_else = {
+							NOT = { has_religion_feature = religion_patriarchal }
+						}
+					}
+
+					persistent_event_target:god_self = {
+						event_target:religion_target = { add_god_name = PREV_FNAME }
+					}
+				}
+
+				if = {
+					limit = { # Father
+						persistent_event_target:god_dad = {
+							always = yes
+						}
+					}
+
+					if = {
+						limit = {
+							NOT = { has_religion_feature = religion_matriarchal }
+						}
+
+						persistent_event_target:god_dad = {
+							event_target:religion_target = { add_god_name = PREV_FNAME }
+						}
+					}
+					else = {
+						persistent_event_target:god_dad = {
+							event_target:religion_target = { add_evil_god_name = PREV_FNAME }
+						}
+					}
+				}
+
+				if = {
+					limit = { # Mother
+						persistent_event_target:god_mom = {
+							always = yes
+						}
+					}
+
+					if = {
+						limit = {
+							NOT = { has_religion_feature = religion_patriarchal }
+						}
+
+						persistent_event_target:god_mom = {
+							event_target:religion_target = { add_god_name = PREV_FNAME }
+						}
+					}
+					else = {
+						persistent_event_target:god_mom = {
+							event_target:religion_target = { add_evil_god_name = PREV_FNAME }
+						}
+					}
+				}
+
+				if = {
+					limit = { # Spouse
+						persistent_event_target:god_spouse = {
+							always = yes
+						}
+					}
+
+					persistent_event_target:god_spouse = {
+						event_target:religion_target = { add_god_name = PREV_FNAME }
+					}
+				}
+
+				if = {
+					limit = { # Child
+						persistent_event_target:god_child = {
+							always = yes
+						}
+					}
+
+					persistent_event_target:god_child = {
+						event_target:religion_target = { add_god_name = PREV_FNAME }
+					}
+				}
+
+				if = {
+					limit = { # Sibling
+						persistent_event_target:god_sibling = {
+							always = yes
+						}
+					}
+
+					persistent_event_target:god_sibling = {
+						event_target:religion_target = { add_god_name = PREV_FNAME }
+					}
+				}
+			}
+		}
+
+		if = { # Religion is Patriarchal
+			limit = { has_religion_feature = religion_patriarchal }
+
+			if = {
+				limit = {
+					religion = aztec_pagan_reformed
+				}
+
+				add_god_name = GOD_HUITZILOPOCHTLI_2
+				add_god_name = GOD_XIPE_TOTEC
+				add_god_name = GOD_TEZCATLIPOCA
+				add_god_name = GOD_QUETZALCOATL
+				add_god_name = GOD_TLALOC
+				add_evil_god_name = TLAZOLTEOTL
+				add_evil_god_name = GOD_MICTLANTECUHTLI
+				add_evil_god_name = XOLOTL
+			}
+			else_if = {
+				limit = {
+					religion = baltic_pagan_reformed
+				}
+
+				add_god_name = GOD_DIEVAS_2
+				add_god_name = GOD_PERKUNAS
+				add_evil_god_name = GOD_LAIMA
+			}
+			else_if = {
+				limit = {
+					religion = bon_pagan_reformed
+				}
+
+				add_god_name = GOD_ADI
+				add_god_name = GOD_AMNYE_MACHEN
+				add_god_name = GOD_DRALHA_YESI
+				add_god_name = GOD_SHENLA_OKAR
+				add_god_name = GOD_SHINJE
+				add_god_name = GOD_ZHANG_ZHUNG_MERI
+				add_evil_god_name = GOD_SHERAB_CHAMMA
+				add_evil_god_name = GOD_YESHE_WALMO
+			}
+			else_if = {
+				limit = {
+					religion = finnish_pagan_reformed
+				}
+
+				add_god_name = GOD_UKKO_2
+				add_evil_god_name = GOD_MASTOR_AVA
+				add_evil_god_name = GOD_KALMA
+
+				if = {
+					limit = {
+						NOT = { has_religion_feature = religion_dogmatic }
+					}
+
+					add_god_name = GOD_PERKELE
+					add_god_name = GOD_JUMI
+					add_god_name = GOD_THE_GREAT_BEAR
+					add_god_name = GOD_TAPIO
+					add_god_name = GOD_TAARA
+					add_god_name = GOD_OMOL
+				}
+			}
+			else_if = {
+				limit = {
+					religion = hellenic_pagan_reformed
+				}
+
+				if = {
+					limit = {
+						has_flag = greek_reformation
+					}
+
+					add_evil_god_name = GOD_APHRODITE
+					add_evil_god_name = GOD_HERA
+					add_evil_god_name = GOD_ATHENA
+					add_evil_god_name = GOD_ARTEMIS
+					add_evil_god_name = GOD_DELFINE
+
+					if = { # Dogmatics only get one
+						limit = {
+							NOT = { has_religion_feature = religion_dogmatic }
+						}
+
+						add_god_name = GOD_GREEK_JUPITER_2 # Otherwise shows Conclave...
+						add_god_name = GOD_POSEIDON_2
+						add_god_name = GOD_HADES
+						add_god_name = GOD_ARES
+						add_god_name = GOD_HEPHAESTUS
+						add_god_name = GOD_APOLLO
+					}
+				}
+				else = {
+					add_evil_god_name = GOD_VENUS
+					add_evil_god_name = GOD_JUNO
+					add_evil_god_name = GOD_MINERVA
+					add_evil_god_name = GOD_DIANA
+					add_evil_god_name = GOD_DELFINE
+
+					if = { # Dogmatics only get one
+						limit = {
+							NOT = { has_religion_feature = religion_dogmatic }
+						}
+
+						add_god_name = GOD_JUPITER_2
+						add_god_name = GOD_NEPTUNE_2
+						add_god_name = GOD_PLUTO
+						add_god_name = GOD_MARS
+						add_god_name = GOD_VULCAN
+						add_god_name = GOD_APOLLO
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					religion = norse_pagan_reformed
+				}
+
+				add_god_name = GOD_ODIN_2
+				add_evil_god_name = GOD_FRIGG
+				add_evil_god_name = HEL
+				add_evil_god_name = GOD_SIF
+				add_evil_god_name = GOD_SKADI
+
+				if = {
+					limit = {
+						NOT = { has_religion_feature = religion_dogmatic }
+					}
+
+					add_god_name = GOD_THOR
+					add_god_name = GOD_THE_THUNDERER
+					add_god_name = GOD_THE_ALLFATHER
+					add_god_name = GOD_TYR
+				}
+			}
+			else_if = {
+				limit = {
+					religion = slavic_pagan_reformed
+				}
+
+				add_god_name = GOD_PERUN_2
+				add_evil_god_name = GOD_VELES
+				add_evil_god_name = GOD_MEDEINA
+
+				if = {
+					limit = {
+						NOT = { has_religion_feature = religion_dogmatic }
+					}
+
+					add_god_name = GOD_JARILO
+					add_god_name = GOD_SVAROG
+					add_god_name = GOD_TRIGLAV
+					add_god_name = GOD_RADEGAST
+				}
+			}
+			else_if = {
+				limit = {
+					religion = tengri_pagan_reformed
+				}
+
+				add_god_name = GOD_TENGRI_2
+				add_god_name = GOD_TUNG-AK
+				add_evil_god_name = GOD_AK_ANA
+				add_evil_god_name = KOMUR_HAN
+			}
+		}
+		else_if = { # Religion is Matriarchal
+			limit = { has_religion_feature = religion_matriarchal }
+
+			if = {
+				limit = {
+					religion = aztec_pagan_reformed
+				}
+
+				add_god_name = GOD_CIHUACOATL_2
+				add_god_name = GOD_MALINALXOCHITL
+				add_god_name = GOD_METZTLI
+				add_god_name = GOD_TONACACIHUATL
+				add_evil_god_name = TLAZOLTEOTL
+				add_evil_god_name = GOD_MICTLANTECUHTLI
+				add_evil_god_name = XOLOTL
+			}
+			else_if = {
+				limit = {
+					religion = baltic_pagan_reformed
+				}
+
+				add_god_name = GOD_GABIJA_2
+				add_god_name = GOD_LAIMA
+				add_evil_god_name = VELNIAS
+			}
+			else_if = {
+				limit = {
+					religion = bon_pagan_reformed
+				}
+
+				add_god_name = GOD_SHERAB_CHAMMA
+				add_god_name = GOD_YESHE_WALMO
+				add_evil_god_name = GOD_AMNYE_MACHEN
+				add_evil_god_name = GOD_SHINJE
+			}
+			else_if = {
+				limit = {
+					religion = finnish_pagan_reformed
+				}
+
+				add_god_name = GOD_KUU_2
+				add_evil_god_name = TUONI
+				add_evil_god_name = TUONETAR
+
+				if = {
+					limit = {
+						NOT = { has_religion_feature = religion_dogmatic }
+					}
+
+					add_god_name = GOD_MASTOR_AVA
+					add_god_name = GOD_KALMA
+					add_god_name = GOD_THE_GREAT_BEAR
+				}
+			}
+			else_if = {
+				limit = {
+					religion = hellenic_pagan_reformed
+				}
+
+				if = {
+					limit = {
+						has_flag = greek_reformation
+					}
+
+					add_god_name = GOD_HERA_2
+					add_evil_god_name = GOD_HADES
+					add_evil_god_name = GOD_GREEK_JUPITER # Otherwise shows Conclave...
+					add_evil_god_name = GOD_POSEIDON
+					add_evil_god_name = GOD_ARES
+					add_evil_god_name = GOD_TYPHON
+
+					if = { # Dogmatics only get one
+						limit = {
+							NOT = { has_religion_feature = religion_dogmatic }
+						}
+
+						add_god_name = GOD_DEMETRA
+						add_god_name = GOD_ATHENA
+						add_god_name = GOD_APHRODITE
+						add_god_name = GOD_ARTEMIS
+						add_god_name = GOD_HESTIA
+					}
+				}
+				else = {
+					add_god_name = GOD_JUNO_2
+					add_evil_god_name = GOD_PLUTO
+					add_evil_god_name = GOD_JUPITER
+					add_evil_god_name = GOD_NEPTUNE
+					add_evil_god_name = GOD_MARS
+					add_evil_god_name = GOD_TYPHON
+
+					if = { # Dogmatics only get one
+						limit = {
+							NOT = { has_religion_feature = religion_dogmatic }
+						}
+
+						add_god_name = GOD_CERES
+						add_god_name = GOD_MINERVA
+						add_god_name = GOD_VENUS
+						add_god_name = GOD_DIANA
+						add_god_name = GOD_VESTA
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					religion = norse_pagan_reformed
+				}
+
+				add_god_name = GOD_FRIGG_2
+				add_evil_god_name = LOKI
+				add_evil_god_name = GOD_THE_THUNDERER
+				add_evil_god_name = FENRIR
+				add_evil_god_name = JORMUNGANDR
+
+				if = {
+					limit = {
+						NOT = { has_religion_feature = religion_dogmatic }
+					}
+
+					add_god_name = GOD_SIF
+					add_god_name = GOD_THE_ALLMOTHER
+					add_god_name = GOD_SKADI
+					add_god_name = GOD_FREY
+				}
+			}
+			else_if = {
+				limit = {
+					religion = slavic_pagan_reformed
+				}
+
+				add_god_name = GOD_MEDEINA_2
+				add_evil_god_name = GOD_VELES
+				add_evil_god_name = CHERNOBOG
+
+				if = {
+					limit = {
+						NOT = { has_religion_feature = religion_dogmatic }
+					}
+
+					add_god_name = GOD_DODOLA
+					add_god_name = GOD_KOSTROMA
+					add_god_name = GOD_MARZANNA
+				}
+			}
+			else_if = {
+				limit = {
+					religion = tengri_pagan_reformed
+				}
+
+				add_god_name = GOD_UMAY_2
+				add_god_name = GOD_AK_ANA
+				add_god_name = GOD_KUBAI
+				add_evil_god_name = ERLIK
+				add_evil_god_name = KOMUR_HAN
+			}
+		}
+		else = { # Religion is not sexist
+			if = {
+				limit = {
+					religion = aztec_pagan_reformed
+				}
+
+				if = { # add just Proselytizing set
+					limit = { has_religion_feature = religion_proselytizing }
+
+					add_god_name = GOD_QUETZALCOATL_2
+					add_evil_god_name = GOD_TEZCATLIPOCA
+				}
+				else_if = { # add just Dogmatic set
+					limit = { has_religion_feature = religion_dogmatic 	}
+
+					add_god_name = GOD_HUITZILOPOCHTLI_2
+					add_evil_god_name = TLAZOLTEOTL
+				}
+			}
+			else_if = {
+				limit = {
+					religion = baltic_pagan_reformed
+				}
+
+				add_god_name = GOD_DIEVAS_2
+				add_evil_god_name = VELNIAS
+			}
+			else_if = {
+				limit = {
+					religion = bon_pagan_reformed
+				}
+
+				add_god_name = GOD_SANGPO_BUMTRI_2
+				add_evil_god_name = GOD_THE_EVIL_ONES
+			}
+			else_if = {
+				limit = {
+					religion = finnish_pagan_reformed
+				}
+
+				add_god_name = GOD_UKKO_2
+				add_evil_god_name = TUONI
+			}
+			else_if = {
+				limit = {
+					religion = hellenic_pagan_reformed
+				}
+
+				if = {
+					limit = {
+						has_flag = greek_reformation
+					}
+
+					if = { # Poseidon finally gets his due
+						limit = { has_religion_feature = religion_seafaring }
+						add_god_name = GOD_POSEIDON_2
+					}
+					else = {
+						add_god_name = GOD_GREEK_JUPITER_2 # Otherwise shows Conclave...
+					}
+					add_evil_god_name = GOD_HADES
+					add_evil_god_name = GOD_KRONOS
+					add_evil_god_name = GOD_DIONYSUS
+					add_evil_god_name = GOD_HERMES
+					add_evil_god_name = GOD_TYPHON
+
+					if = { # Dogmatics only get one
+						limit = {
+							NOT = { has_religion_feature = religion_dogmatic }
+						}
+
+						add_god_name = GOD_HADES
+						add_god_name = GOD_HERA
+						add_god_name = GOD_DEMETRA
+						add_god_name = GOD_ATHENA
+						add_god_name = GOD_ARES
+						add_god_name = GOD_HEPHAESTUS
+						add_god_name = GOD_APHRODITE
+						add_god_name = GOD_APOLLO
+						add_god_name = GOD_ARTEMIS
+						add_god_name = GOD_HESTIA
+					}
+				}
+				else = {
+					if = { # Poseidon finally gets his due
+						limit = { has_religion_feature = religion_seafaring }
+						add_god_name = GOD_NEPTUNE_2
+					}
+					else = {
+						add_god_name = GOD_JUPITER_2
+					}
+					add_evil_god_name = GOD_SATURN
+					add_evil_god_name = GOD_PLUTO
+					add_evil_god_name = GOD_BACCHUS
+					add_evil_god_name = GOD_MERCURY
+					add_evil_god_name = GOD_TYPHON
+
+					if = { # Dogmatics only get one
+						limit = {
+							NOT = { has_religion_feature = religion_dogmatic }
+						}
+
+						add_god_name = GOD_PLUTO
+						add_god_name = GOD_JUNO
+						add_god_name = GOD_CERES
+						add_god_name = GOD_MINERVA
+						add_god_name = GOD_MARS
+						add_god_name = GOD_VULCAN
+						add_god_name = GOD_VENUS
+						add_god_name = GOD_APOLLO
+						add_god_name = GOD_DIANA
+						add_god_name = GOD_VESTA
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					religion = norse_pagan_reformed
+				}
+
+				add_god_name = GOD_THE_ALLFATHER_2
+				add_evil_god_name = LOKI
+				add_evil_god_name = HEL
+				add_evil_god_name = FENRIR
+				add_evil_god_name = JORMUNGANDR
+			}
+			else_if = {
+				limit = {
+					religion = slavic_pagan_reformed
+				}
+
+				add_god_name = GOD_PERUN_2
+				add_evil_god_name = GOD_VELES
+				add_evil_god_name = CHERNOBOG
+			}
+			else_if = {
+				limit = {
+					religion = tengri_pagan_reformed
+				}
+
+				add_god_name = GOD_TENGRI_2
+				add_evil_god_name = ERLIK
+				add_evil_god_name = KOMUR_HAN
+			}
 		}
 	}
 }

--- a/CleanSlate/events/base_on_action_events.txt
+++ b/CleanSlate/events/base_on_action_events.txt
@@ -4057,7 +4057,140 @@ narrative_event = {
 			hellenic_pagan_reformed = { hellenic_pagan = { set_flag = has_been_reformed } }
 		}
 
-		reformation_god_names_changes_effect = yes
+		# (High)God name setup
+		religion_scope = {
+			persistent_event_target:religion_title = {
+				export_reformer_to_title_effect = yes
+			}
+			rebuild_god_name_effect = yes
+			if = {
+				limit = {
+					OR = {
+						has_religion_feature = religion_holy_family
+						has_religion_feature = religion_feature_zun
+					}
+					has_religion_feature = religion_temporal_head
+				}
+
+				set_high_god_name = string_reformer_god
+			}
+			else_if = { # Religion is Patriarchal
+				limit = { has_religion_feature = religion_patriarchal }
+
+				trigger_switch = {
+					on_trigger = religion
+
+					aztec_pagan_reformed        = {}
+					baltic_pagan_reformed       = {}
+					bon_pagan_reformed          = {}
+					finnish_pagan_reformed      = {}
+					hellenic_pagan_reformed     = {
+						if = {
+							limit = {
+								has_flag = greek_reformation
+							}
+							if = { # Poseidon finally gets his due
+								limit = { has_religion_feature = religion_seafaring }
+								set_high_god_name = GOD_POSEIDON
+							}
+							else = {
+								set_high_god_name = GOD_GREEK_JUPITER # Otherwise shows Conclave...
+							}
+						}
+						else = {
+							if = { # Poseidon finally gets his due
+								limit = { has_religion_feature = religion_seafaring }
+								set_high_god_name = GOD_NEPTUNE
+							}
+							else = {
+								set_high_god_name = GOD_JUPITER
+							}
+						}
+					}
+					norse_pagan_reformed        = {}
+					slavic_pagan_reformed       = {}
+					tengri_pagan_reformed       = {}
+					west_african_pagan_reformed = {}
+					zun_pagan_reformed          = {}
+				}
+			}
+			else_if = { # Religion is Matriarchal
+				limit = { has_religion_feature = religion_matriarchal }
+
+				trigger_switch = {
+					on_trigger = religion
+
+					aztec_pagan_reformed        = { set_high_god_name = GOD_CIHUACOATL }
+					baltic_pagan_reformed       = { set_high_god_name = GOD_GABIJA}
+					bon_pagan_reformed          = {}
+					finnish_pagan_reformed      = { set_high_god_name = GOD_KUU }
+					hellenic_pagan_reformed     = {
+						if = {
+							limit = {
+								has_flag = greek_reformation
+							}
+
+							set_high_god_name = GOD_HERA
+						}
+						else = {
+							set_high_god_name = GOD_JUNO
+						}
+					}
+					norse_pagan_reformed        = { set_high_god_name = GOD_FRIGG }
+					slavic_pagan_reformed       = { set_high_god_name = GOD_MEDEINA }
+					tengri_pagan_reformed       = { set_high_god_name = GOD_UMAY }
+					west_african_pagan_reformed = { set_high_god_name = GOD_THE_MOTHER }
+					zun_pagan_reformed          = {}			
+				}
+			}
+			else_if = { # Else
+				limit = { has_religion_features = yes }
+				trigger_switch = {
+					on_trigger = religion
+
+					aztec_pagan_reformed        = {
+						if = {
+							limit = { has_religion_feature = religion_proselytizing }
+							set_high_god_name = GOD_QUETZALCOATL
+						}
+						else = {
+							set_high_god_name = GOD_HUITZILOPOCHTLI
+						}
+					}
+					baltic_pagan_reformed       = {}
+					bon_pagan_reformed          = {}
+					finnish_pagan_reformed      = {}
+					hellenic_pagan_reformed     = {
+						if = {
+							limit = {
+								has_flag = greek_reformation
+							}
+							if = { # Poseidon finally gets his due
+								limit = { has_religion_feature = religion_seafaring }
+								set_high_god_name = GOD_POSEIDON
+							}
+							else = {
+								set_high_god_name = GOD_GREEK_JUPITER # Otherwise shows Conclave...
+							}
+						}
+						else = {
+							if = { # Poseidon finally gets his due
+								limit = { has_religion_feature = religion_seafaring }
+								set_high_god_name = GOD_NEPTUNE
+							}
+							else = {
+								set_high_god_name = GOD_JUPITER
+							}
+						}
+					}
+					norse_pagan_reformed        = { set_high_god_name = GOD_THE_ALLFATHER }
+					slavic_pagan_reformed       = {}
+					tengri_pagan_reformed       = {}
+					west_african_pagan_reformed = {}
+					zun_pagan_reformed          = {}			
+				}
+			}
+		}
 
 		# Voting rules aren't enabled automatically for relgion head title created in code
 		if = {

--- a/CleanSlate/localisation/00_scope_shim.csv
+++ b/CleanSlate/localisation/00_scope_shim.csv
@@ -1,0 +1,9 @@
+ROOT_NAME;[Root.GetName];[Root.GetName];[Root.GetName];;[Root.GetName];;;;;;;;;x
+PREV_NAME;[Prev.GetName];[Prev.GetName];[Prev.GetName];;[Prev.GetName];;;;;;;;;x
+FROM_NAME;[From.GetName];[From.GetName];[From.GetName];;[From.GetName];;;;;;;;;x
+ROOT_ADJ;[Root.GetAdjective];[Root.GetAdjective];[Root.GetAdjective];;[Root.GetAdjective];;;;;;;;;x
+PREV_ADJ;[Prev.GetAdjective];[Prev.GetAdjective];[Prev.GetAdjective];;[Prev.GetAdjective];;;;;;;;;x
+FROM_ADJ;[From.GetAdjective];[From.GetAdjective];[From.GetAdjective];;[From.GetAdjective];;;;;;;;;x
+ROOT_FNAME;[Root.GetFirstName];[Root.GetFirstName];[Root.GetFirstName];;[Root.GetFirstName];;;;;;;;;x
+PREV_FNAME;[Prev.GetFirstName];[Prev.GetFirstName];[Prev.GetFirstName];;[Prev.GetFirstName];;;;;;;;;x
+FROM_FNAME;[From.GetFirstName];[From.GetFirstName];[From.GetFirstName];;[From.GetFirstName];;;;;;;;;x


### PR DESCRIPTION
With Holy Fury, Reformed pagan religion can have their god names changed
However it's broken within a year of releasing

I managed to refactor the name change process and add shortcut
for scoping from a religion to head title, and vice versa