### PR TITLE
Fix wrong scope in culture conversion_decisions

### DIFF
--- a/CleanSlate/decisions/conversion_decisions.txt
+++ b/CleanSlate/decisions/conversion_decisions.txt
@@ -562,17 +562,19 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = swedish
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = norse
 					employer = { character = ROOT }
 				}
+
 				culture = swedish
 			}
 		}
@@ -703,17 +705,19 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = norwegian
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = norse
 					employer = { character = ROOT }
 				}
+
 				culture = norwegian
 			}
 		}
@@ -843,17 +847,19 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = danish
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = norse
 					employer = { character = ROOT }
 				}
+
 				culture = danish
 			}
 		}
@@ -980,17 +986,19 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = norman
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = norse
 					employer = { character = ROOT }
 				}
+
 				culture = norman
 			}
 		}
@@ -1481,13 +1489,14 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = french
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = frankish
 					employer = { character = ROOT }
@@ -1590,13 +1599,14 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = scottish
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = pictish
 					employer = { character = ROOT }
@@ -1710,6 +1720,8 @@ targeted_decisions = {
 			culture = andalusian_arabic
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -1813,13 +1825,14 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = castilian
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -1923,13 +1936,14 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = catalan
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2037,13 +2051,14 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = portuguese
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2150,13 +2165,14 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = dutch
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2282,6 +2298,8 @@ targeted_decisions = {
 			culture = italian
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2392,13 +2410,14 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = occitan
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2497,13 +2516,14 @@ targeted_decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {
 			culture = russian
 
 			any_dynasty_member = {
+				show_scope_change = no
+
 				limit = {
 					culture_group = east_slavic
 					employer = { character = ROOT }
@@ -3534,7 +3554,6 @@ decisions = {
 		}
 
 		allow = {
-			always = yes
 		}
 
 		effect = {

--- a/CleanSlate/decisions/conversion_decisions.txt
+++ b/CleanSlate/decisions/conversion_decisions.txt
@@ -568,7 +568,7 @@ targeted_decisions = {
 		effect = {
 			culture = swedish
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = norse
 					employer = { character = ROOT }
@@ -709,7 +709,7 @@ targeted_decisions = {
 		effect = {
 			culture = norwegian
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = norse
 					employer = { character = ROOT }
@@ -849,7 +849,7 @@ targeted_decisions = {
 		effect = {
 			culture = danish
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = norse
 					employer = { character = ROOT }
@@ -986,7 +986,7 @@ targeted_decisions = {
 		effect = {
 			culture = norman
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = norse
 					employer = { character = ROOT }
@@ -1487,7 +1487,7 @@ targeted_decisions = {
 		effect = {
 			culture = french
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = frankish
 					employer = { character = ROOT }
@@ -1596,7 +1596,7 @@ targeted_decisions = {
 		effect = {
 			culture = scottish
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = pictish
 					employer = { character = ROOT }
@@ -1709,7 +1709,7 @@ targeted_decisions = {
 		effect = {
 			culture = andalusian_arabic
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -1819,7 +1819,7 @@ targeted_decisions = {
 		effect = {
 			culture = castilian
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -1929,7 +1929,7 @@ targeted_decisions = {
 		effect = {
 			culture = catalan
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2043,7 +2043,7 @@ targeted_decisions = {
 		effect = {
 			culture = portuguese
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2156,7 +2156,7 @@ targeted_decisions = {
 		effect = {
 			culture = dutch
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2281,7 +2281,7 @@ targeted_decisions = {
 		effect = {
 			culture = italian
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2398,7 +2398,7 @@ targeted_decisions = {
 		effect = {
 			culture = occitan
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture = ROOT
 					employer = { character = ROOT }
@@ -2503,7 +2503,7 @@ targeted_decisions = {
 		effect = {
 			culture = russian
 
-			any_close_relative = {
+			any_dynasty_member = {
 				limit = {
 					culture_group = east_slavic
 					employer = { character = ROOT }
@@ -2679,7 +2679,7 @@ targeted_decisions = {
 			custom_tooltip = {
 				text = tooltip_courtiers_embrace_outremer
 
-				any_close_relative = {
+				any_dynasty_member = {
 					limit = {
 						culture = ROOT
 						employer = { character = ROOT }


### PR DESCRIPTION
misused 'any_close_relative' instead of 'any_dynasty_member',
making it not equivalent to vanilla tooltip

Fix #116