### PR TITLE
battle: add flag clean up and minor fix

### DIFF
--- a/CleanSlate/common/cb_types/adventurer_cbs.txt
+++ b/CleanSlate/common/cb_types/adventurer_cbs.txt
@@ -799,6 +799,8 @@ manifest_destiny_invasion = {
 
 			if = {
 				limit = {
+					uses_decadence = yes
+
 					NOT = {
 						any_liege = {
 							dynasty = PREV

--- a/CleanSlate/common/cb_types/china_cbs.txt
+++ b/CleanSlate/common/cb_types/china_cbs.txt
@@ -609,7 +609,7 @@ offmap_submission = {
 			if = {
 				limit = { has_character_flag = is_rebel_general }
 
-				end_war = invalid
+				PREV = { end_war = invalid }
 
 				any_courtier = {
 					death = { death_reason = death_went_back_to_china }

--- a/CleanSlate/common/cb_types/other_cbs.txt
+++ b/CleanSlate/common/cb_types/other_cbs.txt
@@ -1187,7 +1187,7 @@ unjust_conquest = {
 					text = custom_opinion_hit_tooltip_enemy
 
 					any_realm_lord = {
-						limit = { is_landed = yes }
+						limit = { religion = defender }
 
 						opinion = {
 							name = opinion_declared_unjust_conquest

--- a/CleanSlate/common/cb_types/religious_cbs.txt
+++ b/CleanSlate/common/cb_types/religious_cbs.txt
@@ -2315,25 +2315,23 @@ religious = {
 						FROM = { religion = taoist }
 					}
 
+					# Muslims fight amongst themselves
+					trigger_else_if = {
+						limit = { religion_group = muslim }
+						NOR = {
+							religion = FROM
+							FROM = { # Not fighting religious enemies
+								any_current_enemy = {
+									NOT = { religion_group = muslim }
+								}
+							}
+						}
+					}
+
 					# Can holy war known demon worshippers in he same religion group
 					trigger_if = {
 						limit = { FROM = { has_character_modifier = known_satanist } }
 						NOT = { has_character_modifier = known_satanist }
-					}
-				}
-			}
-
-			# Requirements for Muslims
-			trigger_else_if = {
-				limit = { religion_group = muslim }
-
-				NOT = { religion = FROM }
-
-				FROM = {
-					NOT = { # Not fighting religious enemies
-						any_current_enemy = {
-							NOT = { religion_group = muslim }
-						}
 					}
 				}
 			}
@@ -2467,18 +2465,18 @@ religious = {
 						FROM = { religion = taoist }
 					}
 
+					# Muslims fight amongst themselves
+					trigger_else_if = {
+						limit = { religion_group = muslim }
+						NOT = { religion = FROM }
+					}
+
 					# Can holy war known demon worshippers in the same religion group
 					AND = {
 						FROM = { has_character_modifier = known_satanist }
 						NOT = { has_character_modifier = known_satanist }
 					}
 				}
-			}
-
-			# Requirements for Muslims
-			trigger_else_if = {
-				limit = { religion_group = muslim }
-				NOT = { religion = FROM }
 			}
 
 			top_liege = {

--- a/CleanSlate/common/cb_types/republic_cbs.txt
+++ b/CleanSlate/common/cb_types/republic_cbs.txt
@@ -489,9 +489,9 @@ embargo_cb = {
 						}
 					}
 				}
-			}
 
-			prestige = -100
+				prestige = -100
+			}
 		}
 
 		any_attacker = { # attacking merchant republics pay dearly for not winning
@@ -502,7 +502,7 @@ embargo_cb = {
 				NOT = { character = attacker }
 			}
 
-			prestige = -1000
+			prestige = -100
 		}
 
 		defender = {

--- a/CleanSlate/common/cb_types/vassal_liege_cbs.txt
+++ b/CleanSlate/common/cb_types/vassal_liege_cbs.txt
@@ -506,10 +506,7 @@ overthrow_ruler = {
 
 		# Defender
 		FROM = {
-			any_demesne_title = {
-				NOT = { lower_tier_than = ROOT }
-				temporary = no
-			}
+			higher_real_tier_than = ROOT
 		}
 	}
 

--- a/CleanSlate/events/HF_battle_events.txt
+++ b/CleanSlate/events/HF_battle_events.txt
@@ -1654,12 +1654,7 @@ character_event = {
 		# For consistency between description and event options
 		random_list = {
 			33 = { set_character_flag = desc_A }
-
-			33 = {
-				trigger = { NOT = { event_target:enemy_commander = { always = yes } } }
-				set_character_flag = desc_B
-			}
-
+			33 = { set_character_flag = desc_B }
 			33 = { set_character_flag = desc_C }
 		}
 
@@ -1669,9 +1664,8 @@ character_event = {
 					is_alive = yes
 					ai = yes
 				}
+				disallow_new_battle_events_effect = yes # To keep the tombola from spamming your potential target...
 			}
-
-			disallow_new_battle_events_effect = yes # To keep the tombola from spamming your potential target...
 		}
 
 		set_battle_duels_option_flag_effect = yes
@@ -1721,10 +1715,15 @@ character_event = {
 		name = EVTOPT_HFP_11010_C
 		tooltip_info = combat_rating
 
-		trigger = { has_character_flag = high_PCS_opt }
+		trigger = {
+			has_character_flag = high_PCS_opt
+
+			NOT = { event_target:enemy_commander = { always = yes } }
+		}
 
 		prestige = 15
 		pacifists_lose_piety_effect = yes
+		allow_new_battle_events_effect = yes
 
 		ai_chance = { factor = 6 }
 	}
@@ -1850,6 +1849,16 @@ character_event = {
 		prestige = 15
 		allow_new_battle_events_effect = yes
 
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
+
 		ai_chance = { factor = 2 }
 	}
 
@@ -1866,6 +1875,16 @@ character_event = {
 		}
 
 		allow_new_battle_events_effect = yes
+
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
 
 		ai_chance = {
 			factor = 1
@@ -1899,6 +1918,16 @@ character_event = {
 		prestige = -50
 		allow_new_battle_events_effect = yes
 
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
+
 		ai_chance = {
 			factor = 2
 
@@ -1922,6 +1951,9 @@ character_event = {
 		clr_character_flag = duel_enemy_opt_gain_brave
 		clr_character_flag = duel_enemy_opt_is_brave
 
+		clr_character_flag = desc_A
+		clr_character_flag = desc_B
+		clr_character_flag = desc_C
 	}
 }
 
@@ -1961,7 +1993,6 @@ character_event = {
 	immediate = {
 		disallow_new_battle_events_effect = yes # To keep the tombola from spamming you...
 		battle_commander_counter_negative_effect = yes
-		save_beloved_character_effect = yes # event_target:my_beloved (might be platonic, children, etc)
 		set_battle_duels_option_flag_effect = yes
 
 		event_target:enemy_commander = {
@@ -1970,9 +2001,12 @@ character_event = {
 					is_alive = yes
 					ai = yes
 				}
+				disallow_new_battle_events_effect = yes # To keep the tombola from spamming your potential target...
 			}
+		}
 
-			disallow_new_battle_events_effect = yes # To keep the tombola from spamming your potential target...
+		hidden_effect = {
+			save_beloved_character_effect = yes # event_target:my_beloved (might be platonic, children, etc)
 		}
 
 		random_list = {
@@ -2060,6 +2094,7 @@ character_event = {
 
 		apply_duel_wounded_effect = yes # Milder than other options
 		add_blood_splatter_effect = yes
+		allow_new_battle_events_effect = yes
 
 		ai_chance = { factor = 300 }
 	}
@@ -2202,6 +2237,16 @@ character_event = {
 
 		allow_new_battle_events_effect = yes
 
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
+
 		ai_chance = { factor = 100 }
 	}
 
@@ -2299,6 +2344,16 @@ character_event = {
 
 		allow_new_battle_events_effect = yes
 
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
+
 		ai_chance = {
 			factor = 50
 
@@ -2363,6 +2418,16 @@ character_event = {
 
 		allow_new_battle_events_effect = yes
 
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
+
 		ai_chance = {
 			factor = 50
 
@@ -2387,6 +2452,9 @@ character_event = {
 		clr_character_flag = duel_enemy_opt
 		clr_character_flag = duel_enemy_opt_gain_brave
 		clr_character_flag = duel_enemy_opt_is_brave
+		clr_character_flag = desc_A
+		clr_character_flag = desc_B
+		clr_character_flag = desc_C
 	}
 }
 
@@ -2429,30 +2497,29 @@ character_event = {
 	}
 
 	option = {
-		name = {
-			text = EVTOPTA_HFP_11012
-			trigger = { has_character_flag = wounded_incapable }
-		}
-		name = {
-			text = EVTOPTB_HFP_11012
-			trigger = { has_character_flag = wounded_disfigured }
-		}
+		name = EVTOPTA_HFP_11012
 
-		if = {
-			limit = { has_character_flag = wounded_incapable }
+		trigger = { has_character_flag = wounded_incapable }
 
-			custom_tooltip = { text = EVTOPTA_HFP_11012_tt }
-			add_trait = incapable
-			allow_new_battle_events_effect = yes
-			clr_character_flag = wounded_incapable
-		}
-		else = {
-			custom_tooltip = { text = EVTOPTB_HFP_11012_tt }
-			add_trait = disfigured
-			add_trait = severely_injured
-			resolve_severely_injured_effect = yes
-			clr_character_flag = wounded_disfigured
-		}
+		custom_tooltip = { text = EVTOPTA_HFP_11012_tt }
+		add_trait = incapable
+	}
+
+	option = {
+		name = EVTOPTB_HFP_11012
+
+		trigger = { has_character_flag = wounded_disfigured }
+
+		custom_tooltip = { text = EVTOPTB_HFP_11012_tt }
+		add_trait = disfigured
+		add_trait = severely_injured
+		resolve_severely_injured_effect = yes
+	}
+
+	after = {
+		clr_character_flag = wounded_incapable
+		clr_character_flag = wounded_disfigured
+		allow_new_battle_events_effect = yes
 	}
 }
 
@@ -2899,6 +2966,7 @@ character_event = {
 
 		trigger = { character = event_target:enemy_commander }
 
+		custom_tooltip = { text = EVTOPTA_HFP_10018_tt }
 		add_blood_splatter_effect = yes
 	}
 
@@ -2921,10 +2989,10 @@ character_event = {
 			NOT = { character = event_target:enemy_commander }
 		}
 
+		custom_tooltip = { text = EVTOPTA_HFP_10018_tt }
 	}
 
 	after = {
-		custom_tooltip = { text = EVTOPTA_HFP_10018_tt }
 		allow_new_battle_events_effect = yes
 	}
 }
@@ -3410,9 +3478,9 @@ character_event = {
 	only_capable = yes
 	prisoner = no
 
-	trigger = {
-		is_inaccessible_trigger = no
-	}
+	#trigger = {
+	#	is_inaccessible_trigger = no
+	#}
 
 	immediate = {
 		disallow_new_battle_events_effect = yes # To keep the tombola from spamming you...
@@ -3505,9 +3573,8 @@ character_event = {
 					is_alive = yes
 					ai = yes
 				}
+				disallow_new_battle_events_effect = yes # To keep the tombola from spamming your potential target...
 			}
-
-			disallow_new_battle_events_effect = yes # To keep the tombola from spamming your potential target...
 		}
 
 		random_list = {
@@ -3577,6 +3644,15 @@ character_event = {
 		send_new_dog_event_effect = yes # Will only work for certain bloodlines...
 		clr_character_flag = about_to_challenge_enemy_commander
 		allow_new_battle_events_effect = yes
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
 	}
 
 	option = {
@@ -3612,6 +3688,15 @@ character_event = {
 
 		clr_character_flag = about_to_challenge_enemy_commander
 		allow_new_battle_events_effect = yes
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
 	}
 
 	option = {
@@ -3626,6 +3711,15 @@ character_event = {
 
 		clr_character_flag = about_to_challenge_enemy_commander
 		allow_new_battle_events_effect = yes
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
 	}
 
 	option = {
@@ -3640,6 +3734,15 @@ character_event = {
 
 		clr_character_flag = about_to_challenge_enemy_commander
 		allow_new_battle_events_effect = yes
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
 	}
 
 	option = {
@@ -3652,9 +3755,18 @@ character_event = {
 			remove_character_modifier = pet_hunting_eagle
 		}
 
+		send_new_eagle_event_effect = yes # Only for certain bloodlines...!
 		clr_character_flag = about_to_challenge_enemy_commander
 		allow_new_battle_events_effect = yes
-		send_new_eagle_event_effect = yes # Only for certain bloodlines...!
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
 	}
 
 	option = {
@@ -3669,6 +3781,15 @@ character_event = {
 
 		clr_character_flag = about_to_challenge_enemy_commander
 		allow_new_battle_events_effect = yes
+		event_target:enemy_commander = {
+			if = {
+				limit = {
+					is_alive = yes
+					ai = yes
+				}
+				allow_new_battle_events_effect = yes
+			}
+		}
 	}
 
 	### Chase after the enemy commander (if there is one)
@@ -5651,7 +5772,7 @@ character_event = {
 		prestige = -50
 		save_event_target_as = captured_commander
 		imprison = event_target:enemy_liege # ROOT is imprisoned *by* enemy_liege.
-		event_target:other_combatant = { character_event = { id = 50020 } } # Enemy_liege is notified about your capture...
+		event_target:enemy_liege = { character_event = { id = 50020 } } # Enemy_liege is notified about your capture...
 
 		hidden_effect = {
 			event_target:other_combatant = {
@@ -5800,6 +5921,9 @@ character_event = {
 		clr_character_flag = add_duel_xp # To not give rewards...
 		clr_character_flag = is_battlefield_duel # To not give opinion rewards..
 		allow_new_battle_events_effect = yes
+		event_target:commander_cannon_fodder = {
+			allow_new_battle_events_effect = yes
+		}
 		hidden_effect = { clean_up_after_duel_effect = yes }
 	}
 }
@@ -6287,6 +6411,10 @@ character_event = {
 		NOT = { trait = blinded }
 	}
 
+	fail_trigger_effect = {
+		allow_new_battle_events_effect = yes
+	}
+
 	immediate = {
 		disallow_new_battle_events_effect = yes # To keep the tombola from spamming you...
 
@@ -6379,6 +6507,10 @@ character_event = {
 		}
 	}
 
+	fail_trigger_effect = {
+		allow_new_battle_events_effect = yes
+	}
+
 	immediate = {
 		disallow_new_battle_events_effect = yes # To keep the tombola from spamming you...
 		battle_commander_counter_positive_effect = yes
@@ -6469,6 +6601,9 @@ character_event = {
 		}
 
 		allow_new_battle_events_effect = yes
+		event_target:enemy_commander = {
+			allow_new_battle_events_effect = yes
+		}
 
 		ai_chance = {
 			factor = 100
@@ -6528,6 +6663,10 @@ character_event = {
 				province_id = 1335 # c_kosti
 			}
 		}
+	}
+
+	fail_trigger_effect = {
+		allow_new_battle_events_effect = yes
 	}
 
 	immediate = {


### PR DESCRIPTION
[battle](https://github.com/ck2plus/CleanSlate/commit/894631000e12e26e4399eeba2196c1daf9dbf54c)

- fix high combat (no enemy commander) option trigger in HFP.11010
- do not show portrait on every options in HFP.11011
- split the option in HFP.11012
- remove the unnecessary is_inaccessible_trigger in HFP.11024
- send event to correct target (enemy liege) in HFP.11042

[cb_types](https://github.com/ck2plus/CleanSlate/commit/50ce62b375e2de97a9ebc37bf3f5f603f3dd6ac0)

manifest_destiny_invasion
- only add decadence if use_decadence

offmap_submission
- call end_war in the war scope

unjust_conquest
- only add negative opinion if same religion as defender when declared
  on infidel

religious
- fix muslim holy war

embargo_cb
- fix prestige cost on white peace

overthrow_ruler
- use higher_real_tier_than in is_valid