### PR TITLE
council: fix effect and notification

### DIFF
--- a/CleanSlate/common/job_titles/00_job_titles.txt
+++ b/CleanSlate/common/job_titles/00_job_titles.txt
@@ -94,7 +94,7 @@ job_chancellor = {
 				practical_age < 65
 				health >= 3
 				is_sick_or_injured_trigger = no
-				can_be_councilmember_king_trigger = yes
+				can_be_chancellor_trigger = yes
 			}
 
 			FROM = {
@@ -273,7 +273,7 @@ job_marshal = {
 				practical_age < 65
 				health >= 3
 				is_sick_or_injured_trigger = no
-				can_be_councilmember_king_trigger = yes
+				can_be_marshal_trigger = yes
 			}
 
 			FROM = {
@@ -369,7 +369,7 @@ job_treasurer = {
 				practical_age < 65
 				health >= 3
 				is_sick_or_injured_trigger = no
-				can_be_councilmember_king_trigger = yes
+				can_be_treasurer_trigger = yes
 			}
 
 			FROM = {
@@ -462,7 +462,7 @@ job_spymaster = {
 				practical_age < 65
 				health >= 3
 				is_sick_or_injured_trigger = no
-				can_be_councilmember_king_trigger = yes
+				can_be_spymaster_trigger = yes
 			}
 
 			FROM = {
@@ -562,7 +562,7 @@ job_spiritual = {
 				practical_age < 65
 				health >= 3
 				is_sick_or_injured_trigger = no
-				can_be_councilmember_king_trigger = yes
+				can_be_spiritual_trigger = yes
 			}
 
 			FROM = {

--- a/CleanSlate/common/minor_titles/00_minor_titles.txt
+++ b/CleanSlate/common/minor_titles/00_minor_titles.txt
@@ -3956,7 +3956,7 @@ title_councilmember_king = {
 	retire_effect = {
 		if = {
 			limit = {
-				age < 65
+				practical_age < 65
 				health >= 3
 				is_sick_or_injured_trigger = no
 				can_be_councilmember_king_trigger = yes
@@ -4042,10 +4042,10 @@ title_councilmember_emperor = {
 	retire_effect = {
 		if = {
 			limit = {
-				age < 65
+				practical_age < 65
 				health >= 3
 				is_sick_or_injured_trigger = no
-				can_be_councilmember_king_trigger = yes
+				can_be_councilmember_emperor_trigger = yes
 			}
 
 			FROM = {

--- a/CleanSlate/common/objectives/00_factions.txt
+++ b/CleanSlate/common/objectives/00_factions.txt
@@ -4409,11 +4409,13 @@ faction_independence = {
 			}
 
 			# Not allowed to start factions like this if our capital borders the liege's capital
-			capital_scope = {
-				any_neighbor_province = {
-					ROOT = {
-						capital_scope = {
-							NOT = { province = PREVPREV }
+			NOT = {
+				capital_scope = {
+					any_neighbor_province = {
+						ROOT = {
+							capital_scope = {
+								province = PREVPREV
+							}
 						}
 					}
 				}
@@ -5902,18 +5904,18 @@ faction_claimant = {
 				NOT = { character = FROM }
 			}
 
+			FROM = {
+				NOR = {
+					has_religion_feature = religion_matriarchal
+					has_religion_feature = religion_equal
+					has_religion_feature = religion_feature_bon
+				}
+			}
+
 			trigger_if = {
 				limit = { has_dlc = "Conclave" }
 
 				NOR = {
-					FROM = {
-						OR = {
-							has_religion_feature = religion_matriarchal
-							has_religion_feature = religion_equal
-							has_religion_feature = religion_feature_bon
-						}
-					}
-
 					has_law = status_of_women_4
 
 					has_game_rule = {
@@ -6413,14 +6415,17 @@ faction_claimant = {
 				NOT = { character = ROOT }
 			}
 
+			NOR = {
+				has_religion_feature = religion_equal
+				has_religion_feature = religion_matriarchal
+				has_religion_feature = religion_feature_bon
+			}
+
 			trigger_if = {
 				limit = { has_dlc = "Conclave" }
 
 				NOR = {
 					has_law = status_of_women_4
-					has_religion_feature = religion_equal
-					has_religion_feature = religion_matriarchal
-					has_religion_feature = religion_feature_bon
 
 					has_game_rule = {
 						name = gender

--- a/CleanSlate/common/succession_voting/00_succession_voting_feudal_elective.txt
+++ b/CleanSlate/common/succession_voting/00_succession_voting_feudal_elective.txt
@@ -256,10 +256,10 @@ feudal_elective = {
 
 				# Family relations
 				trigger_if = {
-					limit = { is_close_relative = ROOT }
+					limit = { dynasty = ROOT }
 
 					OR = {
-						dynasty = ROOT
+						is_close_relative = ROOT
 
 						AND = {
 							is_landed = yes
@@ -377,6 +377,7 @@ feudal_elective = {
 
 		# Ageism
 		elector_candidate_age_vote = yes
+		elector_candidate_age_children_vote = yes
 
 		# Culturism
 		elector_candidate_culture_vote = yes

--- a/CleanSlate/common/succession_voting/01_succession_voting_hre_feudal_elective.txt
+++ b/CleanSlate/common/succession_voting/01_succession_voting_hre_feudal_elective.txt
@@ -409,10 +409,10 @@ hre_feudal_elective = {
 				has_claim = ROOT_FROMFROM
 
 				trigger_if = {
-					limit = { is_close_relative = ROOT }
+					limit = { dynasty = ROOT }
 
 					OR = {
-						dynasty = ROOT
+						is_close_relative = ROOT
 
 						AND = {
 							is_landed = yes
@@ -524,6 +524,7 @@ hre_feudal_elective = {
 
 		# Ageism
 		elector_candidate_age_vote = yes
+		elector_candidate_age_children_vote = yes
 
 		# Culturism
 		elector_candidate_culture_vote = yes

--- a/CleanSlate/decisions/rip_various_decisions.txt
+++ b/CleanSlate/decisions/rip_various_decisions.txt
@@ -1248,7 +1248,7 @@ decisions = {
 
 				if = { # Notify employer that councillor is going into seclusion
 					limit = {
-						is_voter = yes
+						is_councillor = yes
 						liege = { ai = no }
 					}
 

--- a/CleanSlate/events/base_job_chancellor.txt
+++ b/CleanSlate/events/base_job_chancellor.txt
@@ -149,6 +149,12 @@ character_event = {
 
 		location = {
 			any_province_lord = {
+				# No reason to improve relations with irrelevant barons
+				trigger_if = {
+					limit = { real_tier = BARON }
+					same_liege = ROOT
+				}
+
 				is_priest = no
 
 				NOR = {
@@ -172,6 +178,11 @@ character_event = {
 			location = {
 				random_province_lord = {
 					limit = {
+						trigger_if = {
+							limit = { real_tier = BARON }
+							same_liege = ROOT
+						}
+
 						is_priest = no
 
 						NOR = {
@@ -1380,7 +1391,7 @@ letter_event = {
 					years = 2
 				}
 
-				letter_event = { id = chancellor.506 }
+				letter_event = { id = chancellor.508 }
 			}
 		}
 	}

--- a/CleanSlate/events/hl_silk_route_events.txt
+++ b/CleanSlate/events/hl_silk_route_events.txt
@@ -1283,9 +1283,9 @@ province_event = {
 							factor = 2 # 20%
 							combat_rating < 10
 						}
-					}
 
-					death = { death_reason = death_battle }
+						death = { death_reason = death_battle }
+					}
 				}
 
 				character_event = {

--- a/CleanSlate/events/rip_seclusion_events.txt
+++ b/CleanSlate/events/rip_seclusion_events.txt
@@ -239,7 +239,7 @@ character_event = {
 		# Notify employer that councillor is going into seclusion
 		if = {
 			limit = {
-				is_voter = yes
+				is_councillor = yes
 				liege = { ai = no }
 			}
 


### PR DESCRIPTION
[councillor](https://github.com/ck2plus/CleanSlate/commit/b779d41ab0654a2dc11982b851ef818af0225064)

- use the corresponding trigger in retire_effect
- use the same selection of lords as improve relation when the attempt
  is sabotaged
- use the correct letter in chancellor.505
- fix marshal death chance tooltip in HL.5050
- advisors has no job title so do not send notification for their
  seclusion

[faction](https://github.com/ck2plus/CleanSlate/commit/463e197bab273ea2225973813825ccaec57e1dd6)

independence
- fix the bordering capital check

claimant
- always check religion for gender equality

[succession](https://github.com/ck2plus/CleanSlate/commit/60e3cadaa4b88d7d3baa74743ce6d0b54c83a8b8)

- can vote for landed dynasty member
- add missing score for child