### PR TITLE
Fixed MR -> Feudal on forming Outremer

### DIFF
--- a/CleanSlate/decisions/HFP_realm_decisions.txt
+++ b/CleanSlate/decisions/HFP_realm_decisions.txt
@@ -1744,7 +1744,12 @@ decisions = {
 					destroy_landed_title = THIS
 				}
 
-				capital = c_jerusalem
+				if = {
+					limit = {
+						is_feudal = yes
+					}
+					capital = c_jerusalem
+				}
 
 				any_landed_title = {
 					limit = {


### PR DESCRIPTION
Creating Outremer causes MRs to become Feudal (or possibly other government changes) since the capital is moved to c_jerusalem, so republics are now excepted from the capital move (less extreme fix than blocking the decision entirely).