### PR TITLE
Remove Powys being incorrectly named "Ternyllwg"

### DIFF
--- a/CleanSlate/common/dynasties/00_dynasties.txt
+++ b/CleanSlate/common/dynasties/00_dynasties.txt
@@ -39563,12 +39563,6 @@
 	religion = catholic
 }
 
-1047018 = {
-	name = "Ternyllwg"
-	culture = welsh
-	religion = catholic
-}
-
 1047019 = {
 	name = "Arllechwydd"
 	culture = welsh

--- a/CleanSlate/history/characters/welsh.txt
+++ b/CleanSlate/history/characters/welsh.txt
@@ -4000,7 +4000,7 @@
 
 159061 = {
 	name = "Casnar" # Wledig
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159057
@@ -4014,7 +4014,7 @@
 
 159062 = {
 	name = "Llary" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159061
@@ -4028,7 +4028,7 @@
 
 159063 = {
 	name = "Rhun" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159062
@@ -4042,7 +4042,7 @@
 
 159064 = {
 	name = "Bywdeg" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159063
@@ -4056,7 +4056,7 @@
 
 159065 = {
 	name = "Bywyr Lew" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159064
@@ -4070,7 +4070,7 @@
 
 159066 = {
 	name = "Gwineu Deufureuddwyd" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159065
@@ -4084,7 +4084,7 @@
 
 159067 = {
 	name = "Teon" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159066
@@ -4098,7 +4098,7 @@
 
 159068 = {
 	name = "Tegonwy" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159067
@@ -4112,7 +4112,7 @@
 
 159069 = {
 	name = "Caenog" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159068
@@ -4126,7 +4126,7 @@
 
 159070 = {
 	name = "Corf" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159069
@@ -4140,7 +4140,7 @@
 
 159071 = {
 	name = "Ceidio" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159070
@@ -4154,7 +4154,7 @@
 
 159072 = {
 	name = "Lles Llawddeog" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159071
@@ -4168,7 +4168,7 @@
 
 159073 = {
 	name = "Caradog" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159072
@@ -4182,7 +4182,7 @@
 
 159074 = {
 	name = "Bleddyn" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159073
@@ -4196,7 +4196,7 @@
 
 159075 = {
 	name = "Gwrydr" #
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159074
@@ -8281,7 +8281,7 @@
 
 184119 = {
 	name = "Iorwerth"
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 159068 #Tegonwy Gruffyd of Powys
@@ -8299,7 +8299,7 @@
 
 184120 = {
 	name = "Idnerth"
-	dynasty = 1047018 #Ternyllwg
+	dynasty = 1029003 # Gwerthrynion
 	religion = catholic
 	culture = welsh
 	father = 184119

--- a/CleanSlate/history/provinces/28 - Powys.txt
+++ b/CleanSlate/history/provinces/28 - Powys.txt
@@ -17,8 +17,6 @@ b_radnor = city
 # b_rhayader
 
 # History
-100.1.1 = { name = "Ternyllwg" }
-808.1.1 = { name = PROV28 }
 1212.1.1 = { b_rhayader = castle }
 
 1227.1.1 = {


### PR DESCRIPTION
This piece of ahistorical information was added to Wikipedia in 2012 and copied by Paradox into their history files with the Charlemagne DLC update. It remained on Wikipedia for eleven years, but as the Youtuber [Cambrian Chronicles](https://www.youtube.com/watch?v=bxKiQcKvzjQ) has detailed, it ultimately derives from the work of an eighteenth-century forger named Iolo Morganwg.

I have fixed it by removing the name "Ternyllwg" from Powys' province file, reverting the characters in `history/characters/welsh.txt` whose dynasty was changed to Ternyllwg (fifteen of them are genealogical characters who previously had the dynasty Gwerthrynion; I extended this to the new characters [Iorwerth](https://en.wikipedia.org/wiki/Iorwerth_Hirflawdd) and his son Idnerth, who are playable in the 769 bookmark) and removing the now-redundant Ternyllwg dynasty from `common/dynasties/00_dynasties.txt`.