### PR TITLE
Replace Murchad mac Donnchada with Toirdelbach mac Tadg as king of Munster

### DIFF
--- a/CleanSlate/history/titles/c_thomond.txt
+++ b/CleanSlate/history/titles/c_thomond.txt
@@ -149,10 +149,6 @@
 }
 
 1063.7.1 = {
-	holder = 83355 # Murchad son of Donnchad
-}
-
-1068.7.1 = {
 	holder = 906 # High-King Toirrdelbach mac Taidg
 }
 

--- a/CleanSlate/history/titles/d_munster.txt
+++ b/CleanSlate/history/titles/d_munster.txt
@@ -211,10 +211,6 @@
 }
 
 1063.7.1 = {
-	holder = 83355 # Murchad son of Donnchad
-}
-
-1068.7.1 = {
 	holder = 906 # High-King Toirrdelbach mac Taidg
 }
 


### PR DESCRIPTION
This piece of ahistorical information was added to Wikipedia in 2006 based on a misreading of the book Irish Kings and High Kings. Paradox copied it into their history files when creating Crusader Kings 2; the original game correctly assigned Toirdelbach as king of Munster from 1063 (when he deposed Donnchad, who went on pilgramage to Rome and died there the following year; Murchad spent the rest of his life trying unsuccessfully to unseat Toirdelbach). As a result of the Youtuber [Maniacal Inc.'s video](https://www.youtube.com/watch?v=tX6W0H9R7yc) they added a game rule to fix it in Crusader Kings 3, but they've never come back and fixed it in Crusader Kings 2.