### PR TITLE
Set a cleanslate_active global flag at startup for mod detection

### DIFF
--- a/CleanSlate/common/on_actions/00_on_actions.txt
+++ b/CleanSlate/common/on_actions/00_on_actions.txt
@@ -1,6 +1,7 @@
 # Character scope
 on_startup = {
 	effect = {
+		set_global_flag = cleanslate_active # Lets other mods detect that CleanSlate is running
 		setup_province_pulse = yes
 		setup_reformed_religion_scope = yes
 		setup_holy_order_religion_scopes = yes


### PR DESCRIPTION
## What

Adds `set_global_flag = cleanslate_active` to the `on_startup` `effect` block in
`common/on_actions/00_on_actions.txt` (one additive line).

## Why

Mods that adapt to CleanSlate — most commonly to its **renamed traits** — have no clean way
to detect at runtime that CleanSlate is loaded. CK2 has no "is this mod active" trigger, and
probing with `add_trait`/`has_*` either errors or can't feed back into script, so the usual
workaround is shipping a separate compatibility sub-mod per dependent mod.

A single global flag set at startup lets any mod detect CleanSlate directly and adjust:

    if = {
        limit = { has_global_flag = cleanslate_active }
        # ... use CleanSlate's trait / ID names ...
    }

## Notes

- `on_startup` is additive across mods, so this doesn't override or conflict with anything.
- Harmless if no mod checks the flag. The name `cleanslate_active` is just for clarity —
  happy to rename to whatever convention you prefer.
