### PR TITLE
Fixed iqta tax/levy laws not revoking _8

### DIFF
--- a/CleanSlate/common/laws/ze_obligation_laws.txt
+++ b/CleanSlate/common/laws/ze_obligation_laws.txt
@@ -622,6 +622,7 @@ laws = {
 			revoke_law = tax_levy_law_iqta_5
 			revoke_law = tax_levy_law_iqta_6
 			revoke_law = tax_levy_law_iqta_7
+			revoke_law = tax_levy_law_iqta_8
 		}
 
 		ai_will_do = {
@@ -678,6 +679,7 @@ laws = {
 			revoke_law = tax_levy_law_iqta_5
 			revoke_law = tax_levy_law_iqta_6
 			revoke_law = tax_levy_law_iqta_7
+			revoke_law = tax_levy_law_iqta_8
 		}
 
 		ai_will_do = {
@@ -743,6 +745,7 @@ laws = {
 			revoke_law = tax_levy_law_iqta_5
 			revoke_law = tax_levy_law_iqta_6
 			revoke_law = tax_levy_law_iqta_7
+			revoke_law = tax_levy_law_iqta_8
 		}
 
 		ai_will_do = {
@@ -808,6 +811,7 @@ laws = {
 			revoke_law = tax_levy_law_iqta_5
 			revoke_law = tax_levy_law_iqta_6
 			revoke_law = tax_levy_law_iqta_7
+			revoke_law = tax_levy_law_iqta_8
 		}
 
 		ai_will_do = {
@@ -874,6 +878,7 @@ laws = {
 			revoke_law = tax_levy_law_iqta_5
 			revoke_law = tax_levy_law_iqta_6
 			revoke_law = tax_levy_law_iqta_7
+			revoke_law = tax_levy_law_iqta_8
 		}
 
 		ai_will_do = {
@@ -939,6 +944,7 @@ laws = {
 			revoke_law = tax_levy_law_iqta_5
 			revoke_law = tax_levy_law_iqta_6
 			revoke_law = tax_levy_law_iqta_7
+			revoke_law = tax_levy_law_iqta_8
 		}
 
 		ai_will_do = {
@@ -1004,6 +1010,7 @@ laws = {
 			revoke_law = tax_levy_law_iqta_5
 			revoke_law = tax_levy_law_iqta_6
 			revoke_law = tax_levy_law_iqta_7
+			revoke_law = tax_levy_law_iqta_8
 		}
 
 		ai_will_do = {
@@ -1069,6 +1076,7 @@ laws = {
 			revoke_law = tax_levy_law_iqta_5
 			revoke_law = tax_levy_law_iqta_6
 			revoke_law = tax_levy_law_iqta_7
+			revoke_law = tax_levy_law_iqta_8
 		}
 
 		ai_will_do = {

--- a/CleanSlate/master_changelog.txt
+++ b/CleanSlate/master_changelog.txt
@@ -494,6 +494,7 @@ Fixed the declined offer response not firing in event ZE.22200
 Merchant republics and elective titles can now take the 'Introduce heir'-decision more consistently
 The 'Groom an Heir' ambition now requires that the heir be of your dynasty, for consistency
 Disallow swapping councillors when already doing so
+Iqta tax/levy laws now properly revoke _8 in their effect chains
 
 
 


### PR DESCRIPTION
## What

Adds `revoke_law = tax_levy_law_iqta_8` to the `effect` block of `tax_levy_law_iqta_0` through `_7` in `common/laws/ze_obligation_laws.txt`.

## Why

Every Iqta law's effect chain revokes `_0`–`_7` but omits `_8`.  The other four obligation families include `_8`.  Any `add_law` (UI vote, scripted effect, console) of an Iqta law leaves residual `_8` if it was set, with the Laws tab showing `_8` as still active along with the new law.

## Notes

- Inherited from vanilla.
